### PR TITLE
Rename plugin to memclaw + schema/prompt fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — memory-unified
+# CLAUDE.md — memclaw
 
 ## What This Is
 
@@ -7,7 +7,7 @@ An OpenClaw memory plugin that unifies conversation memory (LanceDB Pro) and doc
 ## Architecture
 
 ```
-memory-unified plugin (kind: "memory")
+memclaw plugin (kind: "memory")
 ├── Conversation Memory (LanceDB Pro — forked)
 │   ├── All existing tools: recall, store, forget, update
 │   ├── 7-stage scoring pipeline (hybrid, rerank, recency, importance, time decay, length norm, MMR)
@@ -35,7 +35,7 @@ memory-unified plugin (kind: "memory")
 ## Project Structure
 
 ```
-memory-unified/
+memclaw/
 ├── CLAUDE.md              ← you are here
 ├── index.ts               ← plugin entry point (register, hooks, identity)
 ├── openclaw.plugin.json   ← plugin manifest + full config schema
@@ -150,9 +150,9 @@ node --import jiti/register tests/benchmark.ts
 
 ```bash
 # Copy to plugin directory
-cp -r . ~/.openclaw/plugins/memory-unified/
+cp -r . ~/.openclaw/plugins/memclaw/
 
-# Update openclaw.json to load memory-unified instead of memory-lancedb-pro
+# Update openclaw.json to load memclaw instead of memory-lancedb-pro
 # Restart gateway
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# memory-unified
+# memclaw
 
 An [OpenClaw](https://github.com/nichochar/openclaw) memory plugin that unifies conversation memory and document search with shared embedding and reranker backends.
 
@@ -44,8 +44,8 @@ npm install
 node --import jiti/register --test tests/*.test.ts
 
 # Deploy
-cp -r . ~/.openclaw/plugins/memory-unified/
-# Update openclaw.json to load memory-unified, restart gateway
+cp -r . ~/.openclaw/plugins/memclaw/
+# Update openclaw.json to load memclaw, restart gateway
 ```
 
 ## License

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,4 +1,4 @@
-# Benchmarks — memory-unified
+# Benchmarks — memclaw
 
 **Updated:** 2026-03-06
 **Environment:**
@@ -161,7 +161,7 @@ This is the one real UX pain point — and it's an infrastructure issue, not a p
 | ColBERT v2 | 69.3% | 110M | Late interaction |
 | Cohere embed-v3 | 72.2% | Unknown | Vector only, API |
 | OpenAI text-embedding-3-large | 73.0% | Unknown | Vector only, API |
-| **memory-unified unified+cross-rerank** | **86.0%** | 0.6B embed + 0.6B rerank | Two small local models |
+| **memclaw unified+cross-rerank** | **86.0%** | 0.6B embed + 0.6B rerank | Two small local models |
 
 Our pipeline with two 0.6B models running locally on Apple M4 outperforms published vector-only results from much larger cloud models. The cross-encoder reranker compensates for weaker initial embeddings by re-scoring the top candidates with full attention.
 

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -2,13 +2,13 @@
 
 ## Summary
 
-This document compares memory-unified against five prominent AI memory systems: mem0, Zep, MemGPT/Letta, LangChain ConversationMemory, and LlamaIndex Memory. Each system takes a different architectural approach to the core problem of giving LLM-based agents persistent, retrievable memory across conversations and sessions.
+This document compares memclaw against five prominent AI memory systems: mem0, Zep, MemGPT/Letta, LangChain ConversationMemory, and LlamaIndex Memory. Each system takes a different architectural approach to the core problem of giving LLM-based agents persistent, retrievable memory across conversations and sessions.
 
-The landscape divides into two camps: **hosted platforms** (mem0, Zep, Letta Cloud) that offer managed infrastructure with graph-enhanced retrieval, and **library-based solutions** (LangChain, LlamaIndex, memory-unified) that embed directly into application code. memory-unified occupies a unique position as a self-hosted plugin with production-grade hybrid retrieval (vector + BM25 + cross-encoder reranking) and unified document search, running entirely on local infrastructure at zero ongoing cost.
+The landscape divides into two camps: **hosted platforms** (mem0, Zep, Letta Cloud) that offer managed infrastructure with graph-enhanced retrieval, and **library-based solutions** (LangChain, LlamaIndex, memclaw) that embed directly into application code. memclaw occupies a unique position as a self-hosted plugin with production-grade hybrid retrieval (vector + BM25 + cross-encoder reranking) and unified document search, running entirely on local infrastructure at zero ongoing cost.
 
 ## Feature Matrix
 
-| Dimension | memory-unified | mem0 | Zep | MemGPT / Letta | LangChain Memory | LlamaIndex Memory |
+| Dimension | memclaw | mem0 | Zep | MemGPT / Letta | LangChain Memory | LlamaIndex Memory |
 |---|---|---|---|---|---|---|
 | **Retrieval** | Hybrid: vector (LanceDB) + BM25 with RRF fusion, cross-encoder reranking | Hybrid: vector + graph traversal, semantic + relational search | Hybrid: semantic embeddings + BM25 + graph traversal | Tool-based: agent decides when to search archival/recall memory | Simple: buffer, window, summary, or vector store lookup | Composable: buffer, summary, vector block, fact extraction |
 | **Reranking** | Cross-encoder (bge-reranker-v2-m3) in retrieval pipeline | LLM-based relevance scoring; configurable reranking | Implicit via graph community ranking | None (LLM judges relevance in-context) | None | None built-in (can add via node postprocessors) |
@@ -63,7 +63,7 @@ LlamaIndex provides a composable memory system with short-term (FIFO chat buffer
 
 Like LangChain, LlamaIndex memory is a toolkit rather than a turnkey system. It offers slightly more sophistication with its block-based composition and fact extraction, but still lacks hybrid search, reranking, importance scoring, auto-capture with noise filtering, and multi-agent scoping. Its strength is tight integration with LlamaIndex's powerful RAG infrastructure (indexes, query engines, node postprocessors), which means document search and memory can share the same retrieval pipeline.
 
-## Where memory-unified Stands
+## Where memclaw Stands
 
 ### Strengths
 
@@ -78,19 +78,19 @@ Like LangChain, LlamaIndex memory is a toolkit rather than a turnkey system. It 
 
 ### Weaknesses / Gaps
 
-- **No knowledge graph**: mem0 and Zep both leverage graph databases for relational reasoning. memory-unified has no graph layer, which limits multi-hop reasoning and relationship discovery across memories.
-- **No LLM-driven memory extraction**: mem0 and Zep use LLMs to distill conversations into discrete facts and resolve contradictions. memory-unified stores raw content with metadata, relying on retrieval-time scoring rather than storage-time intelligence.
-- **No summarization**: LangChain, LlamaIndex, and MemGPT all offer conversation summarization to manage growing context. memory-unified has no summarization capability, which could become a limitation for very long-running sessions.
-- **No temporal reasoning**: Zep's bi-temporal model tracks when facts were true and when they were ingested. memory-unified has time decay but no explicit temporal validity tracking.
-- **No contradiction resolution**: mem0 automatically detects and resolves contradictory memories. memory-unified requires manual updates via the update tool.
+- **No knowledge graph**: mem0 and Zep both leverage graph databases for relational reasoning. memclaw has no graph layer, which limits multi-hop reasoning and relationship discovery across memories.
+- **No LLM-driven memory extraction**: mem0 and Zep use LLMs to distill conversations into discrete facts and resolve contradictions. memclaw stores raw content with metadata, relying on retrieval-time scoring rather than storage-time intelligence.
+- **No summarization**: LangChain, LlamaIndex, and MemGPT all offer conversation summarization to manage growing context. memclaw has no summarization capability, which could become a limitation for very long-running sessions.
+- **No temporal reasoning**: Zep's bi-temporal model tracks when facts were true and when they were ingested. memclaw has time decay but no explicit temporal validity tracking.
+- **No contradiction resolution**: mem0 automatically detects and resolves contradictory memories. memclaw requires manual updates via the update tool.
 - **Single-node only**: Embedded LanceDB and SQLite limit horizontal scalability. mem0 and Zep scale via managed cloud infrastructure.
-- **No published benchmark numbers**: mem0 has LOCOMO results; Zep has DMR benchmark results. memory-unified has no standardized benchmark evaluation, making it hard to compare retrieval quality objectively.
+- **No published benchmark numbers**: mem0 has LOCOMO results; Zep has DMR benchmark results. memclaw has no standardized benchmark evaluation, making it hard to compare retrieval quality objectively.
 - **OpenClaw-only integration**: Tightly coupled to the OpenClaw plugin SDK. mem0 and Zep offer REST APIs and multi-framework SDKs (LangChain, LlamaIndex, CrewAI integrations).
 - **No Python SDK**: TypeScript-only implementation. mem0, Zep, LangChain, and LlamaIndex all have Python as their primary language.
 
 ## Recommendations
 
-Based on the identified gaps, the following priorities would most improve memory-unified's competitive position:
+Based on the identified gaps, the following priorities would most improve memclaw's competitive position:
 
 1. **Benchmark on standard datasets** (high priority, low effort): Run LOCOMO or DMR benchmarks to produce comparable recall/accuracy numbers. Without published metrics, the sophisticated retrieval pipeline cannot be objectively validated against mem0 or Zep.
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,6 +1,6 @@
 # Unified Memory System — Requirements
 
-**Project:** `memory-unified`
+**Project:** `memclaw`
 **Status:** Complete — 145 tests passing, benchmarks stable, ready for deployment
 **Updated:** 2026-03-05
 
@@ -19,7 +19,7 @@ A single OpenClaw memory plugin that:
 ## Architecture
 
 ```
-memory-unified (OpenClaw plugin, kind: "memory")
+memclaw (OpenClaw plugin, kind: "memory")
 │
 ├── Conversation Memory (LanceDB Pro — forked)
 │   ├── All existing tools: recall, store, forget, update
@@ -158,7 +158,7 @@ Embedding and reranker models are hot-swappable via config. Switching is a `base
 - `gte-reranker-modernbert-base` — local, 149M params, smallest
 
 ### Re-embedding on Model Switch
-- CLI: `memory-unified reindex --all`
+- CLI: `memclaw reindex --all`
 - Detect dimension mismatch on startup → warn + block until reindex
 
 ---
@@ -183,8 +183,8 @@ Embedding and reranker models are hot-swappable via config. Switching is a `base
 
 ## Implementation Steps
 
-1. Fork LanceDB Pro → `~/projects/memory-unified/`
-2. Fork QMD → `~/projects/memory-unified/qmd/` (or as dependency)
+1. Fork LanceDB Pro → `~/projects/memclaw/`
+2. Fork QMD → `~/projects/memclaw/qmd/` (or as dependency)
 3. Modify QMD `llm.ts`: replace node-llama-cpp with OpenAI-compat HTTP client
 4. Add shared embedding/reranker config to plugin
 5. Wire QMD's search functions into the recall path

--- a/docs/plans/2026-03-05-benchmarks-design.md
+++ b/docs/plans/2026-03-05-benchmarks-design.md
@@ -96,7 +96,7 @@ Uses a thin OpenClaw plugin API mock to exercise real tool handlers (auto-captur
 ## 3. Feature Comparison (`docs/COMPARISON.md`)
 
 ### Systems compared
-- **memory-unified** (ours) — live benchmarks
+- **memclaw** (ours) — live benchmarks
 - **mem0** — documentation + published benchmarks
 - **Zep** — documentation + published benchmarks
 - **MemGPT/Letta** — documentation + published benchmarks

--- a/docs/plans/2026-03-05-benchmarks-impl.md
+++ b/docs/plans/2026-03-05-benchmarks-impl.md
@@ -265,7 +265,7 @@ Use web search to gather architecture, features, published benchmarks, pricing f
 Structure:
 1. Feature matrix table (all systems x all dimensions)
 2. Per-system analysis (1-2 paragraphs each)
-3. Strengths and weaknesses of memory-unified
+3. Strengths and weaknesses of memclaw
 4. Recommendations for what to prioritize
 
 Dimensions: retrieval approach, storage backend, memory management, scoping, document search, quality, latency, cost, integration model.
@@ -274,7 +274,7 @@ Dimensions: retrieval approach, storage backend, memory management, scoping, doc
 
 ```bash
 git add docs/COMPARISON.md
-git commit -m "add feature comparison: memory-unified vs mem0, Zep, MemGPT, LangChain, LlamaIndex"
+git commit -m "add feature comparison: memclaw vs mem0, Zep, MemGPT, LangChain, LlamaIndex"
 ```
 
 ---

--- a/index.ts
+++ b/index.ts
@@ -349,7 +349,7 @@ function getPluginVersion(): string {
 
 const memoryUnifiedPlugin = {
   id: "memclaw",
-  name: "Memory (Unified)",
+  name: "Memclaw",
   description: "Unified memory: LanceDB Pro conversation memory + QMD document search with shared embedding/reranker",
   kind: "memory" as const,
 

--- a/index.ts
+++ b/index.ts
@@ -348,7 +348,7 @@ function getPluginVersion(): string {
 // ============================================================================
 
 const memoryUnifiedPlugin = {
-  id: "memory-unified",
+  id: "memclaw",
   name: "Memory (Unified)",
   description: "Unified memory: LanceDB Pro conversation memory + QMD document search with shared embedding/reranker",
   kind: "memory" as const,
@@ -365,7 +365,7 @@ const memoryUnifiedPlugin = {
       validateStoragePath(resolvedDbPath);
     } catch (err) {
       api.logger.warn(
-        `memory-unified: storage path issue — ${String(err)}\n` +
+        `memclaw: storage path issue — ${String(err)}\n` +
         `  The plugin will still attempt to start, but writes may fail.`
       );
     }
@@ -392,15 +392,15 @@ const memoryUnifiedPlugin = {
       try {
         const probe = await embedder.test();
         if (!probe.success) {
-          api.logger.warn(`memory-unified: embedding probe failed — ${probe.error}. Recall may not work.`);
+          api.logger.warn(`memclaw: embedding probe failed — ${probe.error}. Recall may not work.`);
         } else if (probe.dimensions !== vectorDim) {
           api.logger.warn(
-            `memory-unified: dimension mismatch! Config expects ${vectorDim}d but model returns ${probe.dimensions}d. ` +
+            `memclaw: dimension mismatch! Config expects ${vectorDim}d but model returns ${probe.dimensions}d. ` +
             `Set embedding.dimensions to ${probe.dimensions} or use a compatible model.`
           );
         }
       } catch (err) {
-        api.logger.warn(`memory-unified: embedding probe error — ${String(err)}`);
+        api.logger.warn(`memclaw: embedding probe error — ${String(err)}`);
       }
     })();
 
@@ -515,22 +515,22 @@ const memoryUnifiedPlugin = {
 
             if (!silent && (totals.indexed > 0 || totals.updated > 0)) {
               api.logger.info(
-                `memory-unified: indexed ${totals.indexed} new, ${totals.updated} updated, ${totals.unchanged} unchanged, ${totals.removed} removed docs`
+                `memclaw: indexed ${totals.indexed} new, ${totals.updated} updated, ${totals.unchanged} unchanged, ${totals.removed} removed docs`
               );
             }
 
             const backlog = getEmbeddingBacklog(qmdDb);
             if (backlog > 0) {
-              if (!silent) api.logger.info(`memory-unified: embedding ${backlog} document hashes...`);
+              if (!silent) api.logger.info(`memclaw: embedding ${backlog} document hashes...`);
               const embedResult = await embedDocuments(qmdDb, embDims);
               if (!silent) {
                 api.logger.info(
-                  `memory-unified: embedded ${embedResult.embedded} docs (${embedResult.chunks} chunks)${embedResult.errors.length > 0 ? `, ${embedResult.errors.length} errors` : ""}`
+                  `memclaw: embedded ${embedResult.embedded} docs (${embedResult.chunks} chunks)${embedResult.errors.length > 0 ? `, ${embedResult.errors.length} errors` : ""}`
                 );
               }
             }
           } catch (err) {
-            api.logger.warn(`memory-unified: background indexing failed: ${String(err)}`);
+            api.logger.warn(`memclaw: background indexing failed: ${String(err)}`);
           }
         };
 
@@ -544,15 +544,15 @@ const memoryUnifiedPlugin = {
         }
 
         api.logger.info(
-          `memory-unified: QMD document search enabled (db: ${qmdDbFile}, paths: ${config.documents.paths.map((p: any) => p.name).join(", ")})`
+          `memclaw: QMD document search enabled (db: ${qmdDbFile}, paths: ${config.documents.paths.map((p: any) => p.name).join(", ")})`
         );
       } catch (err) {
-        api.logger.warn(`memory-unified: QMD initialization failed (document search disabled): ${String(err)}`);
+        api.logger.warn(`memclaw: QMD initialization failed (document search disabled): ${String(err)}`);
       }
     }
 
     api.logger.info(
-      `memory-unified@${pluginVersion}: plugin registered (db: ${resolvedDbPath}, model: ${config.embedding.model || "text-embedding-3-small"}, documents: ${unifiedRecall.hasDocumentSearch ? "enabled" : "disabled"})`
+      `memclaw@${pluginVersion}: plugin registered (db: ${resolvedDbPath}, model: ${config.embedding.model || "text-embedding-3-small"}, documents: ${unifiedRecall.hasDocumentSearch ? "enabled" : "disabled"})`
     );
 
     // ========================================================================
@@ -586,7 +586,7 @@ const memoryUnifiedPlugin = {
         migrator,
         embedder,
       }),
-      { commands: ["memory-unified"] }
+      { commands: ["memclaw"] }
     );
 
     // ========================================================================
@@ -621,7 +621,7 @@ const memoryUnifiedPlugin = {
             .join("\n");
 
           api.logger.info?.(
-            `memory-unified: injecting ${results.length} memories into context for agent ${agentId}`
+            `memclaw: injecting ${results.length} memories into context for agent ${agentId}`
           );
 
           return {
@@ -633,7 +633,7 @@ const memoryUnifiedPlugin = {
               `</relevant-memories>`,
           };
         } catch (err) {
-          api.logger.warn(`memory-unified: recall failed: ${String(err)}`);
+          api.logger.warn(`memclaw: recall failed: ${String(err)}`);
         }
       });
     }
@@ -718,11 +718,11 @@ const memoryUnifiedPlugin = {
 
           if (stored > 0) {
             api.logger.info(
-              `memory-unified: auto-captured ${stored} memories for agent ${agentId} in scope ${defaultScope}`
+              `memclaw: auto-captured ${stored} memories for agent ${agentId} in scope ${defaultScope}`
             );
           }
         } catch (err) {
-          api.logger.warn(`memory-unified: capture failed: ${String(err)}`);
+          api.logger.warn(`memclaw: capture failed: ${String(err)}`);
         }
       });
     }
@@ -857,9 +857,9 @@ const memoryUnifiedPlugin = {
           }
         }
 
-        api.logger.info(`memory-unified: backup completed (${allMemories.length} entries → ${backupFile})`);
+        api.logger.info(`memclaw: backup completed (${allMemories.length} entries → ${backupFile})`);
       } catch (err) {
-        api.logger.warn(`memory-unified: backup failed: ${String(err)}`);
+        api.logger.warn(`memclaw: backup failed: ${String(err)}`);
       }
     }
 
@@ -868,7 +868,7 @@ const memoryUnifiedPlugin = {
     // ========================================================================
 
     api.registerService({
-      id: "memory-unified",
+      id: "memclaw",
       start: async () => {
         // IMPORTANT: Do not block gateway startup on external network calls.
         // If embedding/retrieval tests hang (bad network / slow provider), the gateway
@@ -893,7 +893,7 @@ const memoryUnifiedPlugin = {
             const retrievalTest = await withTimeout(retriever.test(), 8_000, "retriever.test()");
 
             api.logger.info(
-              `memory-unified: initialized successfully ` +
+              `memclaw: initialized successfully ` +
               `(embedding: ${embedTest.success ? "OK" : "FAIL"}, ` +
               `retrieval: ${retrievalTest.success ? "OK" : "FAIL"}, ` +
               `mode: ${retrievalTest.mode}, ` +
@@ -901,13 +901,13 @@ const memoryUnifiedPlugin = {
             );
 
             if (!embedTest.success) {
-              api.logger.warn(`memory-unified: embedding test failed: ${embedTest.error}`);
+              api.logger.warn(`memclaw: embedding test failed: ${embedTest.error}`);
             }
             if (!retrievalTest.success) {
-              api.logger.warn(`memory-unified: retrieval test failed: ${retrievalTest.error}`);
+              api.logger.warn(`memclaw: retrieval test failed: ${retrievalTest.error}`);
             }
           } catch (error) {
-            api.logger.warn(`memory-unified: startup checks failed: ${String(error)}`);
+            api.logger.warn(`memclaw: startup checks failed: ${String(error)}`);
           }
         };
 
@@ -930,7 +930,7 @@ const memoryUnifiedPlugin = {
               if (config.sessionIndexing!.autoIndexOnce) {
                 const stats = await store.stats();
                 if (stats.totalCount > 0) {
-                  api.logger.info("memory-unified: session indexing skipped (memories already exist)");
+                  api.logger.info("memclaw: session indexing skipped (memories already exist)");
                   return;
                 }
               }
@@ -942,11 +942,11 @@ const memoryUnifiedPlugin = {
               });
 
               api.logger.info(
-                `memory-unified: session indexing complete — ` +
+                `memclaw: session indexing complete — ` +
                 `${result.indexedTurns} indexed from ${result.totalSessions - result.skippedSessions} sessions`
               );
             } catch (err) {
-              api.logger.warn(`memory-unified: session indexing failed: ${String(err)}`);
+              api.logger.warn(`memclaw: session indexing failed: ${String(err)}`);
             }
           };
           // Delay to not block startup
@@ -970,7 +970,7 @@ const memoryUnifiedPlugin = {
         try {
           if (qmdStore) qmdStore.close();
         } catch { /* ignore */ }
-        api.logger.info("memory-unified: stopped");
+        api.logger.info("memclaw: stopped");
       },
     });
   },
@@ -979,7 +979,7 @@ const memoryUnifiedPlugin = {
 
 function parsePluginConfig(value: unknown): PluginConfig {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error("memory-unified config required");
+    throw new Error("memclaw config required");
   }
   const cfg = value as Record<string, unknown>;
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
-  "id": "memory-unified",
-  "name": "Memory (Unified)",
-  "description": "Unified memory: LanceDB Pro conversation memory + QMD document search with shared embedding/reranker and unified recall",
+  "id": "memclaw",
+  "name": "Memclaw",
+  "description": "Unified memory for OpenClaw: LanceDB Pro conversation memory + QMD document search with shared embedding/reranker and unified recall",
   "version": "0.1.0",
   "kind": "memory",
   "configSchema": {
@@ -275,6 +275,40 @@
             "minimum": 1,
             "maximum": 100,
             "default": 15
+          }
+        }
+      },
+      "sessionIndexing": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Bulk-import past conversation sessions as searchable memories",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable session indexing"
+          },
+          "agent": {
+            "type": "string",
+            "default": "main",
+            "description": "Agent name to index sessions from"
+          },
+          "scope": {
+            "type": "string",
+            "default": "global",
+            "description": "Target scope for indexed memories"
+          },
+          "minImportance": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 0.1,
+            "description": "Minimum importance threshold (0.0-1.0)"
+          },
+          "autoIndexOnce": {
+            "type": "boolean",
+            "default": true,
+            "description": "Only auto-index on first startup (skip if memories already exist)"
           }
         }
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "memory-unified",
+  "name": "memclaw",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "memory-unified",
+      "name": "memclaw",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "memory-unified",
+  "name": "memclaw",
   "version": "0.1.0",
   "description": "OpenClaw unified memory plugin: LanceDB Pro conversation memory + QMD document search with shared embedding/reranker",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,7 +59,7 @@ function formatJson(obj: any): string {
 
 export function registerMemoryCLI(program: Command, context: CLIContext): void {
   const memory = program
-    .command("memory-unified")
+    .command("memclaw")
     .description("Enhanced memory management commands (LanceDB Pro)");
 
   // Version

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,6 +1,6 @@
 /**
  * Migration Utilities
- * Migrates data from old memory-lancedb plugin to memory-unified
+ * Migrates data from old memory-lancedb plugin to memclaw
  */
 
 import { homedir } from "node:os";

--- a/src/store.ts
+++ b/src/store.ts
@@ -45,7 +45,7 @@ export const loadLanceDB = async (): Promise<typeof import("@lancedb/lancedb")> 
   try {
     return await lancedbImportPromise;
   } catch (err) {
-    throw new Error(`memory-unified: failed to load LanceDB. ${String(err)}`, { cause: err });
+    throw new Error(`memclaw: failed to load LanceDB. ${String(err)}`, { cause: err });
   }
 };
 

--- a/tests/benchmark.ts
+++ b/tests/benchmark.ts
@@ -1,5 +1,5 @@
 /**
- * Benchmark Suite for memory-unified
+ * Benchmark Suite for memclaw
  *
  * Measures latency, memory usage, and throughput for key operations:
  * 1. Embedding (single + batch)
@@ -114,7 +114,7 @@ function memUsage(): { heapMB: number; rssMB: number } {
 // ============================================================================
 
 async function main() {
-  console.log("=== memory-unified Benchmark Suite ===\n");
+  console.log("=== memclaw Benchmark Suite ===\n");
   console.log(`Date: ${new Date().toISOString()}`);
   console.log(`Node: ${process.version}`);
   const startMem = memUsage();

--- a/tests/helpers/plugin-mock.ts
+++ b/tests/helpers/plugin-mock.ts
@@ -30,8 +30,8 @@ export function createMockPluginApi(): MockPluginApi {
 
   return {
     identity: {
-      pluginId: "memory-unified-mock",
-      pluginName: "memory-unified",
+      pluginId: "memclaw-mock",
+      pluginName: "memclaw",
       pluginVersion: "0.0.0-test",
     },
 

--- a/tests/importance-experiment.ts
+++ b/tests/importance-experiment.ts
@@ -355,17 +355,26 @@ async function scoreLLM(text: string): Promise<{ score: number; raw: string }> {
     model: "Qwen3-0.6B-Instruct",
     messages: [
       {
+        role: "system",
+        content: `Score messages for an AI memory system (0.0-1.0). Remember = preference, decision, fact, technical detail. Forget = greeting, filler, acknowledgment, status, system output, short reactions. Examples:
+"I prefer dark mode" → 0.9
+"Hello" → 0.0
+"We decided to use PostgreSQL" → 0.9
+"OK sounds good" → 0.1
+"Sure, go ahead" → 0.0
+"yeah go for it" → 0.1
+"thanks" → 0.0
+"HEARTBEAT_OK" → 0.0
+"My SSH key is on the bastion host" → 0.8
+Reply with ONLY the score number.`,
+      },
+      {
         role: "user",
-        content: `Rate how memorable this conversation message is for a personal AI assistant's long-term memory.
-Consider: Is this a preference, decision, fact, technical detail, or important context?
-Score 0.0 (not worth remembering) to 1.0 (definitely remember).
-Reply with just the number, nothing else.
-
-Message: "${truncated}"`,
+        content: truncated,
       },
     ],
     temperature: 0.0,
-    max_tokens: 10,
+    max_tokens: 512, // Qwen3 uses reasoning tokens; needs headroom
   };
 
   try {

--- a/tests/simulation-bench.ts
+++ b/tests/simulation-bench.ts
@@ -587,7 +587,7 @@ async function main() {
     process.exit(1);
   }
 
-  console.log("=== memory-unified Usage Simulation Benchmark ===");
+  console.log("=== memclaw Usage Simulation Benchmark ===");
   console.log(`Date: ${new Date().toISOString()}`);
   console.log(`Node: ${process.version}`);
   console.log(`Scenario: ${scenario}`);


### PR DESCRIPTION
## Summary
- **Rename** `memory-unified` → `memclaw` across plugin ID, manifest, package.json, CLI command, and all log prefixes
- **Add `sessionIndexing` config schema** to `openclaw.plugin.json` — the feature was already implemented in code but the JSON schema was missing, so config validation would reject it
- **Improve importance scoring prompt** in `tests/importance-experiment.ts` — use system prompt with few-shot examples and increase `max_tokens` to 512 for Qwen3 reasoning token headroom

## Test plan
- [ ] Run `node --import jiti/register --test tests/*.test.ts` — all 145 tests pass
- [ ] Verify `openclaw memclaw` CLI command works after deploy
- [ ] Confirm log lines show `memclaw:` prefix

Generated with [Claude Code](https://claude.ai/code)