### PR TITLE
chore: repo hygiene — PR template, dependabot, CI on main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Summary
+
+<!-- 1-3 bullets — what changed and why -->
+
+## Test plan
+
+- [ ] tests pass locally (`node --import jiti/register --test tests/*.test.ts`)
+- [ ] manual verification (steps if non-obvious)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Add `.github/PULL_REQUEST_TEMPLATE.md` (Summary + Test plan scaffold)
- Add `.github/dependabot.yml` (weekly grouped npm + github-actions updates)
- Fix `ci.yml` to trigger on `main` instead of stale `master`

## Test plan

- [x] CI workflow change picked up by GitHub on PR creation
- [ ] Dependabot first run lands within a week

Generated with Claude Code