### PR TITLE
fix(release): clawhub CLI syntax + bump to 0.5.14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           mkdir -p /tmp/memex-publish
           cp SKILL.md README.md AGENTS.md CLAUDE.md package.json openclaw.plugin.json index.ts /tmp/memex-publish/
           cp -r src/ /tmp/memex-publish/src/
-          clawhub publish /tmp/memex-publish --slug memex --version "${TAG_VERSION#v}"
+          clawhub package publish /tmp/memex-publish --slug memex --version "${TAG_VERSION#v}"
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.14] — 2026-05-09
+
+**Re-publish of v0.5.13 after release-workflow fix.** v0.5.13 was tagged but its publish job failed because the `clawhub` CLI changed its publish syntax (`clawhub publish` → `clawhub package publish`) and nothing landed on ClaHub. Code is identical to v0.5.13.
+
+### Fixed
+- **`.github/workflows/release.yml`** — use `clawhub package publish <source>` (the old `clawhub publish <source>` form fails with "This looks like a plugin. Use `clawhub package publish <source>` instead.").
+
 ## [0.5.13] — 2026-05-09
 
 **Theme: citation-anchored recall.** Each recalled memory now carries a short stable handle (`[mem:abc12345]`); the LLM is instructed to cite it when used and can `memory_forget` by the anchor. Inspired by ENGRAM-R (`arXiv:2511.12987`), which reports −85% input / −75% reasoning tokens vs full-context with this pattern at maintained accuracy.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memex",
   "name": "Memex",
   "description": "Unified memory for OpenClaw: conversation memory + document search in a single SQLite database",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "kind": "memory",
   "configSchema": {
     "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ofan/memex",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "Unified memory plugin for OpenClaw — conversation memory + document search in a single SQLite database",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
## Summary

The clawhub CLI now requires \`clawhub package publish <source>\` for plugins. The old syntax fails with:

\`\`\`
Error: This looks like a plugin. Use "clawhub package publish <source>" instead.
\`\`\`

The v0.5.13 publish job hit this exact failure ([release run](https://github.com/ofan/memex/actions/runs/25619127825)) — tests passed, the tag exists, but nothing landed on ClaHub and no GitHub Release was created.

This PR:
1. Fixes the workflow (\`clawhub publish\` → \`clawhub package publish\`)
2. Bumps to **0.5.14** in \`package.json\` + \`openclaw.plugin.json\`
3. Adds a CHANGELOG entry noting v0.5.14 is a re-publish of v0.5.13's code

After merge, tag v0.5.14 and the publish should actually land.

## Test plan

- [x] One-line workflow change; behaviour cannot be unit-tested
- [x] Version bump verified locally
- [ ] Verify by tagging v0.5.14 and watching the release workflow succeed

Generated with [Claude Code](https://claude.ai/code)