### PR TITLE
fix(release): clawhub CLI args + workflow_dispatch for re-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,20 @@ name: Release
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to (re-)publish (e.g. v0.5.14)'
+        required: true
+        type: string
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -23,6 +31,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -31,14 +41,14 @@ jobs:
       - name: Publish to ClaHub
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-          TAG_VERSION: ${{ github.ref_name }}
+          TAG_VERSION: ${{ inputs.tag || github.ref_name }}
         run: |
           npm install -g clawhub
           clawhub login --token "$CLAWHUB_TOKEN" --no-browser
           mkdir -p /tmp/memex-publish
           cp SKILL.md README.md AGENTS.md CLAUDE.md package.json openclaw.plugin.json index.ts /tmp/memex-publish/
           cp -r src/ /tmp/memex-publish/src/
-          clawhub package publish /tmp/memex-publish --slug memex --version "${TAG_VERSION#v}"
+          clawhub package publish /tmp/memex-publish --name memex --family code-plugin --version "${TAG_VERSION#v}"
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true


### PR DESCRIPTION
## Summary

v0.5.14 publish failed with \`error: unknown option '--slug'\` ([release run](https://github.com/ofan/memex/actions/runs/25619282044)). The clawhub CLI dropped \`--slug\` in favor of \`--name\` and now requires \`--family <code-plugin|bundle-plugin>\`.

This PR:
1. Replaces \`--slug memex\` → \`--name memex --family code-plugin\`
2. Adds \`workflow_dispatch\` with a \`tag\` input so we can re-publish an existing tag (e.g. v0.5.14) without bumping the version. Both jobs now check out \`inputs.tag || github.ref\`.

After merge, trigger via \`gh workflow run Release --field tag=v0.5.14\` (or the GitHub UI) to actually publish v0.5.14 to ClaHub.

## Test plan

- [x] YAML parses cleanly
- [ ] After merge: \`gh workflow run Release -f tag=v0.5.14\` and confirm publish lands

Generated with [Claude Code](https://claude.ai/code)