### PR TITLE
fix(release): pass --source-repo/--source-commit/--source-ref to clawhub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,22 @@ jobs:
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
           TAG_VERSION: ${{ inputs.tag || github.ref_name }}
+          SOURCE_REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
           npm install -g clawhub
           clawhub login --token "$CLAWHUB_TOKEN" --no-browser
+          SOURCE_COMMIT=$(git rev-parse HEAD)
           mkdir -p /tmp/memex-publish
           cp SKILL.md README.md AGENTS.md CLAUDE.md package.json openclaw.plugin.json index.ts /tmp/memex-publish/
           cp -r src/ /tmp/memex-publish/src/
-          clawhub package publish /tmp/memex-publish --name memex --family code-plugin --version "${TAG_VERSION#v}"
+          clawhub package publish /tmp/memex-publish \
+            --name memex \
+            --family code-plugin \
+            --version "${TAG_VERSION#v}" \
+            --source-repo "$SOURCE_REPO" \
+            --source-commit "$SOURCE_COMMIT" \
+            --source-ref "$TAG_VERSION"
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true


### PR DESCRIPTION
## Summary

clawhub now requires source provenance args for code plugins:

\`\`\`
Error: --source-repo and --source-commit required for code plugins
\`\`\`

This PR adds:
- \`--source-repo\` from \`\$GITHUB_REPOSITORY\`
- \`--source-commit\` from \`git rev-parse HEAD\` (after checkout, so it reflects the tag's SHA on dispatch runs too)
- \`--source-ref\` from the tag name for human readability

After merge: \`gh workflow run Release -f tag=v0.5.14\` to actually publish.

Generated with [Claude Code](https://claude.ai/code)