### PR TITLE
fix(release): openclaw.compat manifest + bump to 0.5.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.5.15] — 2026-05-10
+
+**Re-publish of v0.5.13/v0.5.14 after release-pipeline shakeout.** The clawhub CLI required a sequence of fixes (`--slug` → `--name`, `--family code-plugin`, `--source-repo`/`--source-commit`/`--source-ref`, and finally `openclaw.compat.pluginApi` + `openclaw.build.openclawVersion` in `package.json`). Code is identical to v0.5.13.
+
+### Fixed
+- **`package.json`** — added `openclaw.compat.pluginApi` and `openclaw.build.openclawVersion` (required for external code plugins per the new clawhub validator).
+- **`.github/workflows/release.yml`** — added `workflow_dispatch` trigger so future re-publishes don't need a fresh version bump.
+
 ## [0.5.14] — 2026-05-09
 
 **Re-publish of v0.5.13 after release-workflow fix.** v0.5.13 was tagged but its publish job failed because the `clawhub` CLI changed its publish syntax (`clawhub publish` → `clawhub package publish`) and nothing landed on ClaHub. Code is identical to v0.5.13.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memex",
   "name": "Memex",
   "description": "Unified memory for OpenClaw: conversation memory + document search in a single SQLite database",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "kind": "memory",
   "configSchema": {
     "type": "object",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,13 @@
   "openclaw": {
     "extensions": [
       "./index.ts"
-    ]
+    ],
+    "compat": {
+      "pluginApi": ">=2026.5.7"
+    },
+    "build": {
+      "openclawVersion": "2026.5.7"
+    }
   },
   "scripts": {
     "test": "node --import jiti/register --test tests/*.test.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ofan/memex",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "Unified memory plugin for OpenClaw — conversation memory + document search in a single SQLite database",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
## Summary

The clawhub CLI now requires \`openclaw.compat.pluginApi\` and \`openclaw.build.openclawVersion\` in \`package.json\` for external code plugins. Adds them, matching \`@openclaw/lobster\`'s format. Also bumps to **0.5.15** since these fields must be present in the *tagged commit* (workflow_dispatch checks out the tag, not main).

After merge: tag v0.5.15 and the publish should finally land. v0.5.13 + v0.5.14 stay in git history as failed-publish records.

Generated with [Claude Code](https://claude.ai/code)