### PR TITLE
fix(release): drop --name flag (clawhub derives from package.json)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
           cp SKILL.md README.md AGENTS.md CLAUDE.md package.json openclaw.plugin.json index.ts /tmp/memex-publish/
           cp -r src/ /tmp/memex-publish/src/
           clawhub package publish /tmp/memex-publish \
-            --name memex \
             --family code-plugin \
             --version "${TAG_VERSION#v}" \
             --source-repo "$SOURCE_REPO" \


### PR DESCRIPTION
Drops the `--name memex` flag since clawhub now validates it against package.json's `name` (`@ofan/memex`). Letting clawhub derive the name avoids the mismatch.

After merge: `gh workflow run Release -f tag=v0.5.15`. (workflow_dispatch runs main's workflow file but checks out the tagged commit, so we don't need a new tag.)