### PR TITLE
feat: build step + bump to 0.6.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Build
+        run: npm run build
       - name: Publish to ClaHub
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
@@ -51,6 +53,7 @@ jobs:
           mkdir -p /tmp/memex-publish
           cp SKILL.md README.md AGENTS.md CLAUDE.md package.json openclaw.plugin.json index.ts /tmp/memex-publish/
           cp -r src/ /tmp/memex-publish/src/
+          cp -r dist/ /tmp/memex-publish/dist/
           clawhub package publish /tmp/memex-publish \
             --family code-plugin \
             --version "${TAG_VERSION#v}" \

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ tests/fixtures/longmemeval-cache/chunk-checkpoint.json
 
 # Local MCP config — contains infra hostnames / 1P refs
 .mcp.json
+
+# Compiled output (built at publish time)
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [0.6.0] — 2026-05-10
+
+**Theme: real build step + version-line shift.** ClaHub's validator now requires compiled JS output for TypeScript code plugins. memex now compiles `index.ts` and `src/**/*.ts` to `dist/` at publish time. Source remains the editable artifact; tests still run against `.ts` via jiti. The `memex-v0.6` development branch is concurrently renamed to `memex-v0.7` so its in-flight architectural work (HTTP MCP daemon, dreaming, entity graph, Claude Code plugin) lands as v0.7+ and doesn't collide with the now-shipped v0.6 namespace.
+
+### Added
+- **`tsconfig.build.json`** — extends the main config with `noEmit: false`, `outDir: dist`, excluding tests. Used only for publish.
+- **`build` script** in `package.json` — `tsc --noCheck -p tsconfig.build.json`. `--noCheck` strips types without type-checking (jiti-equivalent semantics; the existing 42 latent type errors are out of scope for this release and will be addressed separately).
+- **`prepublishOnly`** runs build automatically.
+- **`.github/workflows/release.yml`** — runs `npm run build` between `npm ci` and the publish step; copies `dist/` alongside the source files in the publish payload.
+
+### Changed
+- **`.gitignore`** — `dist/` excluded.
+- **Version-line shift:** main bumps to `0.6.0`. The previously-named `memex-v0.6` branch is renamed to `memex-v0.7` (its in-flight features will ship as v0.7+).
+
+### Notes for downstream
+- ClaHub installs of `memex@0.6.0` get pre-built JS in `dist/`. OpenClaw's loader can use either `dist/index.js` or `index.ts` (jiti); local `npm link` deploys still work without running `npm run build`.
+- 42 latent type errors exist in the codebase (jiti was hiding them). They don't block the build (`--noCheck`) but should be cleaned up in a follow-up PR. Run `npx tsc` to see the list.
+
 ## [0.5.15] — 2026-05-10
 
 **Re-publish of v0.5.13/v0.5.14 after release-pipeline shakeout.** The clawhub CLI required a sequence of fixes (`--slug` → `--name`, `--family code-plugin`, `--source-repo`/`--source-commit`/`--source-ref`, and finally `openclaw.compat.pluginApi` + `openclaw.build.openclawVersion` in `package.json`). Code is identical to v0.5.13.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memex",
   "name": "Memex",
   "description": "Unified memory for OpenClaw: conversation memory + document search in a single SQLite database",
-  "version": "0.5.15",
+  "version": "0.6.0",
   "kind": "memory",
   "configSchema": {
     "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ofan/memex",
-  "version": "0.5.15",
+  "version": "0.6.0",
   "description": "Unified memory plugin for OpenClaw — conversation memory + document search in a single SQLite database",
   "type": "module",
   "main": "index.ts",
@@ -57,7 +57,9 @@
     }
   },
   "scripts": {
-    "test": "node --import jiti/register --test tests/*.test.ts"
+    "test": "node --import jiti/register --test tests/*.test.ts",
+    "build": "tsc --noCheck -p tsconfig.build.json",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist",
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["index.ts", "src/**/*.ts"],
+  "exclude": ["node_modules", "src/qmd", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary

ClaHub's validator now requires compiled JS for TypeScript code plugins. Adds a real build step:

- \`tsconfig.build.json\` extends main config (\`noEmit: false\`, \`outDir: dist\`, tests excluded)
- \`npm run build\` = \`tsc --noCheck\` (strips types without type-checking — matches jiti's runtime semantics; 42 latent type errors in the codebase don't block the build, separate cleanup)
- \`prepublishOnly\` auto-builds
- Workflow runs \`npm run build\` and copies \`dist/\` into the publish payload
- \`.gitignore\` excludes \`dist/\`

Single production entrypoint (\`dist/index.js\`). Source stays \`.ts\`. Tests still jiti against \`.ts\`. Local OpenClaw deploys keep working without building.

Bumps **0.5.15 → 0.6.0**.

The in-flight \`memex-v0.6\` branch will be renamed to \`memex-v0.7\` in a separate operation so its work (HTTP MCP, dreaming, entity graph, plugin) ships as v0.7+ and doesn't collide with this 0.6.0 namespace.

## Test plan

- [x] \`npm run build\` produces clean \`dist/index.js\` + \`dist/src/*.js\`
- [x] \`node -e \"import('./dist/index.js')\"\` loads cleanly
- [x] All 557 tests still pass
- [ ] After merge: tag v0.6.0, watch publish actually land on ClaHub

Generated with [Claude Code](https://claude.ai/code)