### PR TITLE
debug(release): list publish payload contents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,11 @@ jobs:
           mkdir -p /tmp/memex-publish
           cp SKILL.md README.md AGENTS.md CLAUDE.md package.json openclaw.plugin.json index.ts /tmp/memex-publish/
           cp -r src/ /tmp/memex-publish/src/
-          cp -r dist/ /tmp/memex-publish/dist/
+          cp -r dist /tmp/memex-publish/dist
+          echo "=== publish payload contents ==="
+          ls -la /tmp/memex-publish
+          echo "=== dist/ ==="
+          ls -la /tmp/memex-publish/dist | head -20
           clawhub package publish /tmp/memex-publish \
             --family code-plugin \
             --version "${TAG_VERSION#v}" \


### PR DESCRIPTION
Diagnostic: v0.6.0 publish failed with 'requires compiled runtime output' even after building dist/. Adding ls output before clawhub call to verify the payload is actually shaped correctly.