### PR TITLE
fix(release): rename staging dir so clawhub picks the right package name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,15 +50,13 @@ jobs:
           npm install -g clawhub
           clawhub login --token "$CLAWHUB_TOKEN" --no-browser
           SOURCE_COMMIT=$(git rev-parse HEAD)
-          mkdir -p /tmp/memex-publish
-          cp SKILL.md README.md AGENTS.md CLAUDE.md package.json openclaw.plugin.json index.ts /tmp/memex-publish/
-          cp -r src/ /tmp/memex-publish/src/
-          cp -r dist /tmp/memex-publish/dist
-          echo "=== publish payload contents ==="
-          ls -la /tmp/memex-publish
-          echo "=== dist/ ==="
-          ls -la /tmp/memex-publish/dist | head -20
-          clawhub package publish /tmp/memex-publish \
+          # Staging dir name = package name (clawhub derives it from basename when --name omitted).
+          STAGE=/tmp/memex
+          mkdir -p "$STAGE"
+          cp SKILL.md README.md AGENTS.md CLAUDE.md package.json openclaw.plugin.json index.ts "$STAGE/"
+          cp -r src/ "$STAGE/src/"
+          cp -r dist "$STAGE/dist"
+          clawhub package publish "$STAGE" \
             --family code-plugin \
             --version "${TAG_VERSION#v}" \
             --source-repo "$SOURCE_REPO" \


### PR DESCRIPTION
Root cause of the 8-iteration publish saga: clawhub was deriving the package name from `/tmp/memex-publish` → 'memex-publish' / 'Memex Publish'. That's a different package from the registered 'memex' entry, hence missing trusted-publisher config and triggering compiled-output requirements that don't apply to the original.

Renames staging to `/tmp/memex`. Re-dispatch v0.6.1 after merge.