### PR TITLE
fix(release): add runtimeExtensions and files (THE actual fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,12 @@ jobs:
           clawhub login --token "$CLAWHUB_TOKEN" --no-browser
           SOURCE_COMMIT=$(git rev-parse HEAD)
           # Staging dir name = package name (clawhub derives it from basename when --name omitted).
+          # Ship compiled output + manifests only (matches @openclaw/lobster's published shape).
+          # Including index.ts/src triggers a clawhub validator complaint that's not satisfied
+          # by sibling dist/ — published packages should be compiled-only.
           STAGE=/tmp/memex
           mkdir -p "$STAGE"
-          cp SKILL.md README.md AGENTS.md CLAUDE.md package.json openclaw.plugin.json index.ts "$STAGE/"
-          cp -r src/ "$STAGE/src/"
+          cp SKILL.md README.md AGENTS.md CLAUDE.md package.json openclaw.plugin.json "$STAGE/"
           cp -r dist "$STAGE/dist"
           clawhub package publish "$STAGE" \
             --family code-plugin \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.6.2] — 2026-05-10
+
+**Add `runtimeExtensions` and `files` to package.json — what clawhub actually wanted.** The "requires compiled runtime output" error from clawhub validator was misleading — the file was always present in `dist/`, but clawhub finds it via the `openclaw.runtimeExtensions` field, not by inferring `./dist/index.js` from the source `./index.ts` entry. `@openclaw/lobster` has this field; memex was missing it. Verified locally with `clawhub package pack`.
+
+### Added
+- **`openclaw.runtimeExtensions: ["./dist/index.js"]`** in `package.json` — points clawhub at compiled output (matches `@openclaw/lobster`'s manifest shape).
+- **`files`** field in `package.json` — npm-pack inclusion list (`dist/**`, manifests, docs).
+
+### Changed
+- **`.github/workflows/release.yml`** — drops `index.ts` and `src/` from the publish payload (matches lobster's compiled-only shape; source is gitignored from the package even though it's in the repo).
+
 ## [0.6.1] — 2026-05-10
 
 **Track `dist/` in git so clawhub finds it.** v0.6.0 built `dist/` correctly in the workflow but clawhub validates against the GitHub source-repo at the tagged commit, not the local publish payload. Since `dist/` was gitignored, clawhub didn't find it. Removing `dist/` from `.gitignore` and committing the compiled output.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memex",
   "name": "Memex",
   "description": "Unified memory for OpenClaw: conversation memory + document search in a single SQLite database",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "kind": "memory",
   "configSchema": {
     "type": "object",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ofan/memex",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Unified memory plugin for OpenClaw — conversation memory + document search in a single SQLite database",
   "type": "module",
   "main": "index.ts",
@@ -49,6 +49,9 @@
     "extensions": [
       "./index.ts"
     ],
+    "runtimeExtensions": [
+      "./dist/index.js"
+    ],
     "compat": {
       "pluginApi": ">=2026.5.7"
     },
@@ -56,6 +59,14 @@
       "openclawVersion": "2026.5.7"
     }
   },
+  "files": [
+    "dist/**",
+    "openclaw.plugin.json",
+    "README.md",
+    "SKILL.md",
+    "AGENTS.md",
+    "CLAUDE.md"
+  ],
   "scripts": {
     "test": "node --import jiti/register --test tests/*.test.ts",
     "build": "tsc --noCheck -p tsconfig.build.json",


### PR DESCRIPTION
Found the real issue. clawhub's 'requires compiled runtime output' error doesn't mean the file is missing — it means the manifest doesn't tell clawhub where to look. Lobster's package.json has `openclaw.runtimeExtensions: ['./dist/index.js']`; memex was missing this field.

Verified locally with `clawhub package pack` — succeeds with the new manifest.