### PR TITLE
Scope-visibility: readable project_name + stats breakdowns (#7)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -410,6 +410,21 @@ export function createMemexMcpServer(options: McpServerOptions) {
     const byScope: Record<string, number> = {};
     for (const row of scopeRows) byScope[row.scope] = row.cnt;
 
+    // Provenance breakdowns from metadata (scope-visibility #7): readable project
+    // name + client identity, so stats answer "which projects / which clients".
+    const metaRows = db.prepare(
+      "SELECT metadata FROM memories WHERE metadata IS NOT NULL AND metadata != ''"
+    ).all() as Array<{ metadata: string }>;
+    const byProject: Record<string, number> = {};
+    const byClient: Record<string, number> = {};
+    for (const row of metaRows) {
+      try {
+        const m = JSON.parse(row.metadata) as { project_name?: string; client?: string };
+        if (m.project_name) byProject[m.project_name] = (byProject[m.project_name] || 0) + 1;
+        if (m.client) byClient[m.client] = (byClient[m.client] || 0) + 1;
+      } catch { /* malformed metadata — skip */ }
+    }
+
     return {
       content: [{
         type: "text",
@@ -417,6 +432,8 @@ export function createMemexMcpServer(options: McpServerOptions) {
           total,
           byCategory,
           byScope,
+          byProject,
+          byClient,
           neverRecalled,
           neverRecalledRatio: total > 0 ? Math.round((neverRecalled / total) * 100) / 100 : 0,
         }),

--- a/src/scope-derive.ts
+++ b/src/scope-derive.ts
@@ -190,6 +190,11 @@ export function deriveScopes(input: DeriveScopesInput): DeriveScopesOutput {
     if (gitInfo.remote) {
       const normalized = normalizeGitRemote(gitInfo.remote);
       metadata.git_remote = normalized;
+      // Readable project name (last path segment of the normalized remote) for
+      // observability — scope-visibility #7. The stable filter key stays
+      // project:<hash>; project_name is human-readable provenance only.
+      const repoName = normalized.replace(/^https?:\/\//, "").split("/").filter(Boolean).pop();
+      if (repoName) metadata.project_name = repoName;
       tags.push(`project:${hashValue(normalized)}`);
     } else {
       // No remote — use local path hash

--- a/tests/scope-visibility-e2e.test.ts
+++ b/tests/scope-visibility-e2e.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Scope-visibility E2E (#7): readable project name + client dimension.
+ *
+ * Validates that deriveScopes emits a human-readable project_name (alongside the
+ * stable project:<hash> filter key) and that explicit.client creates a client:
+ * scope tag — answering "which project / which client" without losing the stable
+ * hash-based isolation.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { deriveScopes } from "../src/scope-derive.js";
+
+describe("E2E: scope-visibility — readable project name + client dimension", () => {
+  it("deriveScopes emits a readable project_name from the git remote (this repo)", () => {
+    const deriv = deriveScopes({ cwd: process.cwd() }); // the memex repo checkout
+    assert.ok(deriv.metadata.project_name, "project_name should be set for a git repo");
+    assert.equal(typeof deriv.metadata.project_name, "string");
+    // The stable filter key is unchanged — project:<hash> still emitted.
+    assert.ok(deriv.tags.some(t => t.startsWith("project:")), "project:<hash> tag still present");
+  });
+
+  it("explicit.client emits a client: scope tag + records metadata.client", () => {
+    const deriv = deriveScopes({ cwd: process.cwd(), explicit: { client: "claude-code" } });
+    assert.ok(deriv.tags.includes("client:claude-code"), "client:claude-code tag should be emitted");
+    assert.equal(deriv.metadata.client, "claude-code");
+  });
+
+  it("without explicit.client, client stays provenance-only (no client: tag)", () => {
+    const deriv = deriveScopes({ cwd: process.cwd() });
+    assert.ok(!deriv.tags.some(t => t.startsWith("client:")), "no client: tag without explicit client");
+  });
+});


### PR DESCRIPTION
deriveScopes emits a readable project_name (repo name) alongside project:<hash>; memory_stats adds byProject/byClient. Client dimension supported via MEMEX_CLIENT_NAME (activate in daemon env). E2e-validated. Generated with [Claude Code](https://claude.ai/code)