### PR TITLE
fix: dedupe typebox with openclaw + raise node floor to 22.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "openclaw": "^2026.6.11",
         "picomatch": "^4.0.5",
         "sqlite-vec": "^0.1.7-alpha.2",
-        "typebox": "^1.3.6",
+        "typebox": "^1.1.39",
         "yaml": "^2.9.0"
       },
       "bin": {
@@ -45,19 +45,6 @@
       },
       "peerDependencies": {
         "hono": "^4"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -1185,29 +1172,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -5557,9 +5521,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.6.tgz",
-      "integrity": "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA==",
+      "version": "1.1.39",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.39.tgz",
+      "integrity": "sha512-vj0afVtOfLQvv0GR0VxVagYxsXN64btL7Z9XoaG0ZggH3mruMMkOO6hXdgMsjCY3shZgEvooAWVeznQVs5c43w==",
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -5627,16 +5591,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/ofan/memex/issues"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.19.0"
   },
   "files": [
     "dist/**",
@@ -44,7 +44,7 @@
     "openclaw": "^2026.6.11",
     "picomatch": "^4.0.5",
     "sqlite-vec": "^0.1.7-alpha.2",
-    "typebox": "^1.3.6",
+    "typebox": "^1.1.39",
     "yaml": "^2.9.0"
   },
   "openclaw": {


### PR DESCRIPTION
Addresses two codex P2 review comments on #104.

## 1. TypeBox dual-instance (the real one)
#104 bumped root `typebox` to `^1.3.6`, but openclaw 2026.6.11 pins typebox at exactly `1.1.39`. Result: npm installs **two** typebox instances:

```
├─┬ openclaw@2026.6.11
│ └── typebox@1.1.39
└── typebox@1.3.6
```

`src/tools.ts` builds tool schemas importing `Type` from the root package and `stringEnum`/plugin API from openclaw — across two TypeBox instances this **reintroduces the dual-TypeBox incompatibility the repo previously removed** (loop 016), risking `tsc`/tool-registration failures in production.

**Fix:** pin root `typebox` to `1.1.39` so npm dedupes to a single instance:
```
├─┬ openclaw@2026.6.11
│ └── typebox@1.1.39
└── typebox@1.1.39   ← deduped
```

## 2. Node floor
openclaw 2026.6.x pulls `undici` which requires `node >=22.19.0`, but `engines.node` advertised `>=22`. Users on Node 22.14–22.18 would satisfy memex's range only to hit an engine-strict install failure. Raise to `>=22.19.0`.

Tests: 909/909.

Generated with [Claude Code](https://claude.ai/code)