### PR TITLE
fix: exact-pin typebox to 1.1.39 to guarantee dedup with openclaw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "openclaw": "^2026.6.11",
         "picomatch": "^4.0.5",
         "sqlite-vec": "^0.1.7-alpha.2",
-        "typebox": "^1.1.39",
+        "typebox": "1.1.39",
         "yaml": "^2.9.0"
       },
       "bin": {
@@ -32,7 +32,7 @@
         "typescript": "^6.0.3"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "openclaw": "^2026.6.11",
     "picomatch": "^4.0.5",
     "sqlite-vec": "^0.1.7-alpha.2",
-    "typebox": "^1.1.39",
+    "typebox": "1.1.39",
     "yaml": "^2.9.0"
   },
   "openclaw": {


### PR DESCRIPTION
Follow-up to codex P2 on #105.

#105 used a caret range (`^1.1.39`) — but a caret can legally resolve root typebox to `1.3.x` on a fresh install or lockfile regen, while openclaw pins exactly `1.1.39`. That reintroduces the dual-TypeBox instance bug in `src/tools.ts` (Type from root + stringEnum from openclaw) that #105 was meant to fix.

openclaw/plugin-sdk/core doesn't re-export `Type` (only `stringEnum`/helpers), so we can't source Type from the openclaw side. Exact pinning is the correct fix — guarantees root and openclaw always share one typebox instance.

```
├─┬ openclaw@2026.6.11
│ └── typebox@1.1.39
└── typebox@1.1.39   ← exact, no drift possible
```

Tests: 909/909.

Generated with [Claude Code](https://claude.ai/code)