### PR TITLE
docs: review + update all repo docs against current code (v0.7.3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # memex
 
-Unified memory plugin for OpenClaw — conversation memory + document search in a single SQLite database. **~892 tests, 51 files.**
+Unified memory plugin for OpenClaw — conversation memory + document search in a single SQLite database. **~909 tests.**
 
 ## Architecture
 
@@ -28,32 +28,32 @@ in `src/retriever.ts`:
    `timeDecay ×(0.5+0.5*exp(-age/60))` compound; both universal, applied post-rerank with no
    relevance gate. A 1-day-old memory gets ~+0.09 and ~×1.0; a 60-day-old relevant one gets ~+0
    and ×0.60. The ~0.4-pt temporal swing exceeds the ~0.15 relevance spread.
-2. **Dead reranker** — `rerank="cross-encoder"` (jina-reranker-v3) is the default, but
-   `rerankApiKey` is unset, so the cross-encoder is silently skipped every query. The system
-   runs vector+BM25 only.
-3. **No confidence floor / always pads** — `applyAdaptiveMinScore = max(best*0.3, 0.15)` returns
-   ~`limit` results almost no matter what. No abstention (return 1, or 0).
+2. **Reranker now wired (FIXED in #103)** — `MEMEX_RERANK_*` env vars now plumb through
+   `createMemexMcpServer` to the retriever. Cross-encoder and LLM reranker both activate when
+   their respective env vars are set. The flip alone is no longer a no-op.
+3. **hardMinScore now wired (FIXED in #95)** — `applyAdaptiveMinScore` uses `config.hardMinScore`
+   (default 0.15). Kill-switch `MEMEX_HARD_MIN_SCORE_OVERRIDE` for emergency tuning. Abstention
+   (return 1 or 0) is not yet implemented — still under design.
 4. **Miscalibrated fusion** — `fusionMethod="weighted"` (raw cosine[0,1] × unbounded BM25). The
    file header claims RRF but the default is weighted; RRF is a supported option.
-5. **Counter disconnected** — `recordRecalls` (DB `recall_count`) runs only on the auto-inject
-   path; `memory_recall` increments only an in-memory `recallFrequency`. `neverRecalled 99%` is
-   an artifact, not a real signal.
+5. **Counter now wired (FIXED F5 in #95)** — `recordRecalls` (DB `recall_count`) now runs on
+   the MCP `memory_recall` path too (both unified and BM25-fallback branches). The old
+   `neverRecalled 99%` artifact should resolve gradually as recalls accrue.
 6. **dream "deep" ≠ cleanup** — `deepSweep` is ephemeral/session-import decay only; dedup +
    noise removal live in `lightSweep`. Running "deep" no-ops when nothing qualifies.
-7. **Provenance stripped** — `sources` (vector/lexical/reranked) is tracked internally but
-   omitted from the `memory_recall` output.
+7. **Provenance now exposed (FIXED in #95)** — `sources` (vector/lexical/reranked) is
+   included in `memory_recall` output via the `source` field. Each result shows whether it
+   came from vector, lexical (BM25), or was reranked.
 
-**Recall-quality design (design only, not implemented):** `docs/design/recall-quality-design.md` —
+**Recall-quality design (partially implemented):** `docs/design/recall-quality-design.md` —
 the canonical spec (supersedes the earlier retrieval-redesign, validation-analysis, and
 feedback-loop docs, now under `docs/design/archive/`). It has been through a spec-review + 2
-adversarial self-review rounds. Direction: **z-score fusion** (RRF is *not* wired into the
-memory retriever despite the stale `retriever.ts:3` header — it's real plumbing, not a config
-flip), revive **Qwen3-Reranker-0.6B** (already deployed in v0.7; not BGE) on the MCP path
-(requires wiring `MEMEX_RERANK_*` env vars into `createMemexMcpServer` — the flip alone is a
-no-op), cap+gate temporal, wire the dead `hardMinScore` + confidence floor + AutoCut +
-abstention (return 1 or 0, with an agent-facing low-confidence guardrail), expose provenance,
-and a bounded recall-frequency boost. Validation plan + TDD tests + sequencing (5 waves + 5
-gates) are in the same doc.
+adversarial self-review rounds. **Shipped in #95/#103:** z-score fusion, MEMEX_RERANK_* MCP
+wiring (cross-encoder + LLM reranker), hardMinScore wired via applyAdaptiveMinScore,
+recordRecalls on MCP path (F5), provenance in memory_recall output, CoT filter,
+cap-temporal behind MEMEX_RELEVANCE_FIRST, 500 added to transient retries. **Still design-only:**
+confidence floor + AutoCut + abstention (return 1 or 0), bounded recall-frequency boost.
+Validation plan + TDD tests + sequencing (5 waves + 5 gates) are in the same doc.
 
 ## Key Files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,43 @@
 
 ---
 
+## [0.7.3] — 2026-07-09
+
+**Theme: recall-quality correctness + production wiring.** Wires the reranker into the MCP path, fixes dead config (hardMinScore, recordRecalls), adds LLM-based reranker, retries on 500, and hardens dependency resolution. Domain eval expanded to 26 queries with Wilson 95% CI: baseline 69%, cross-encoder 77%, LLM reranker 85%.
+
+### Added
+- **LLM reranker** (`src/rerankers/llm-reranker.ts`) — ordering-based relevance judge using a chat model (deepseek-v4-flash). Opt-in via `MEMEX_RERANK_LLM_MODEL`. Uses `node:http` directly (not fetch) to avoid chunked-encoding issues with the nginx ingress. Quality: 85% on domain eval (vs 69% baseline, 77% cross-encoder).
+- **`src/transient-retry.ts`** — retry helper for embedding + reranker clients. Retries on 500/502/503/504 (llama.cpp "Compute error" returns 500 for transient OOM/queue-full) + network timeouts (AbortError/TimeoutError). 4 attempts with exponential backoff (1s, 2s, 4s).
+- **`MEMEX_HARD_MIN_SCORE_OVERRIDE` env var** — runtime kill-switch for the absolute score floor. Set to override `config.hardMinScore` without redeploy.
+- **`MEMEX_RELEVANCE_FIRST` env flag** (opt-in, off by default) — caps recency to a tie-break (+0.05 max) and relevance-gates it (no boost when score < 0.40). Disables multiplicative timeDecay.
+- **Domain eval expansion** (PR #97) — 26 queries (was 15), Wilson 95% CI on hit rate, `QUERY_DELAY_MS` pacing, `RERANK` env supports `"1"|"cross-encoder"|"llm"|"none"`.
+- **Scope-visibility** (PR #100) — `memory_stats` now returns `byProject` and `byClient` breakdowns read from metadata JSON. Makes scope tags human-readable.
+
+### Fixed
+- **F5: `recordRecalls` wired in MCP path** (`src/mcp-server.ts`) — `memory_recall` now calls `store.recordRecalls()` in both the retriever and BM25 fallback paths. Fixes the 99.26% zero `recall_count` data-corruption bug (Gap 10).
+- **F12: `hardMinScore` wired** (`src/retriever.ts`) — `applyAdaptiveMinScore` now reads `this.config.hardMinScore` instead of hardcoding `0.15`. Default changed from 0.40 to 0.15 (preserves pre-fix behavior). Kill-switch via `MEMEX_HARD_MIN_SCORE_OVERRIDE`. 8+ test files that set `hardMinScore: 0.0` were vacuously testing at the old hardcoded floor.
+- **Reranker enabled in MCP path** (PR #103) — `createMemexMcpServer` reads `MEMEX_RERANK_ENDPOINT`, `MEMEX_RERANK_API_KEY`, `MEMEX_RERANK_MODEL` and dynamically sets `rerank: "cross-encoder"` (or `"llm"` when `MEMEX_RERANK_LLM_MODEL` is set). Was hardcoded `rerank: "none"` (C5, Gap 5).
+- **CoT filter in dreaming** (`src/dreaming.ts`) — `filterLlmCommentary` strips LLM meta-commentary from reflection learnings (13 purged, PR #95).
+- **`@modelcontextprotocol/sdk` declared as direct dependency** (PR #104) — was transitive via openclaw; broke when openclaw bumped its peer. Pinned at `^1.29.0`.
+- **Typebox dedup with openclaw** (PRs #105, #106) — exact-pin `typebox` to `1.1.39` to guarantee single copy (dual-instance breaks `tools.ts`). Paired with openclaw's matching pin.
+- **`/health` exempt from auth** (PR #101) — Docker/k8s liveness probes can check `/health` without a bearer token.
+- **Secrets hygiene** (PRs #98, #99) — anonymized domain eval queries and original eval. Broadened secret-pattern guidance in AGENTS.md.
+
+### Changed
+- **`better-sqlite3` 11.x → 12.11.1** (PR #75) — Node 26 compatible native bindings.
+- **Node engine floor raised to >=22.19.0** (PR #105) — required by undici dep via openclaw.
+- **`openai` ^6.46.0** — dependency bumps.
+- **Temporal signals behind `MEMEX_RELEVANCE_FIRST` flag** (PR #96) — off by default, prevents recency from overriding relevance.
+
+### Known gap
+- `VERSION` in `src/mcp-server.ts` is still `"0.7.2"` (UNFIXED as of 0.7.3 — needs bump to 0.7.3).
+- `retriever.ts:3` header comment still says "RRF fusion" instead of "weighted or zscore fusion".
+- `openclaw.plugin.json` `openclawVersion` is `"2026.5.7"` — should be `"2026.6.11"` matching the `openclaw` dep.
+- Domain eval uses zscore fusion (0.8/0.2 weights), not the production weighted default (0.7/0.3) — config drift remains (Gap 4).
+- Plugin auto-recall hook still uses legacy scope derivation (deferred to T2.1/T2.2).
+
+---
+
 ## [0.7.2] — 2026-05-11
 
 **Theme: configuration ergonomics + debug visibility.** Three user-visible improvements on top of v0.7.1, all backward-compatible. Test count 725 → 740 (+15). `npm audit` still 0.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Memex's 94% is honestly self-measured and reproducible from this repo, but a lea
 
 ### Domain eval
 
-A 15-query entity-rich eval against the author's production memex DB lives at `tests/domain-eval.ts`. It's the primary regression gate for day-to-day retrieval tuning because it runs in under 10s with no LLM cost. Current score: 12/15 without reranker, 11/15 with Qwen3-Reranker (one query loses to a "defensible but wrong" semantic match). See `docs/plans/LEARNINGS.md` for the history.
+A 26-query entity-rich eval against the author's production memex DB lives at `tests/domain-eval.ts`. It's the primary regression gate for day-to-day retrieval tuning because it runs in under 10s with no LLM cost. Scores reported with Wilson 95% confidence intervals: baseline 69%, cross-encoder (Qwen3-Reranker) 77%, LLM reranker (DeepSeek-V4-Flash) 85%. See `docs/plans/PROGRESS.md` for the history.
 
 ### Model bakeoff harness
 
@@ -84,8 +84,9 @@ This is why memex is a `memory` plugin instead of a plain search plugin: the goa
 
 - **7 tools**: `memory_recall`, `memory_store`, `memory_forget`, `memory_dream`, `memory_stats` (MCP server) + `memory_update`, `memory_list` (plugin) + `document_search` — 5 MCP tools, 7 total via plugin
 - **Hybrid retrieval**: z-score fusion (vector + BM25), max-sim chunked embedding
-- **Cross-encoder reranking**: configurable (Jina / SiliconFlow / Voyage / Pinecone shapes). Default off; enable via config when running against an instruction-capable reranker like Qwen3-Reranker-0.6B.
-- **Transient-failure retry**: embedder and reranker clients both retry on 502/503/504/timeouts with exponential backoff (`src/transient-retry.ts`), so inference-server crashes never propagate to callers as failed recalls.
+- **Cross-encoder reranking**: configurable (Jina / SiliconFlow / Voyage / Pinecone shapes). Default off; enable via `MEMEX_RERANK_*` env vars or config when running against an instruction-capable reranker like Qwen3-Reranker-0.6B.
+- **LLM-based reranking**: optional alternative to cross-encoder (DeepSeek-V4-Flash via ordering-based prompt). Opt-in via `MEMEX_RERANK_LLM_MODEL`; highest-quality option at ~85% domain-eval accuracy.
+- **Transient-failure retry**: embedder and reranker clients both retry on 500/502/503/504/timeouts with exponential backoff (`src/transient-retry.ts`), so inference-server crashes never propagate to callers as failed recalls.
 - **Document search**: FTS5 + sqlite-vec, dual-granularity (whole-doc + section/bullet)
 - **Auto-recall**: injects relevant memories into prompt every turn, with an in-turn dedup cache so multiple prompt rebuilds per agent turn only cost one retrieve() call
 - **LLM-driven storage**: system prompt nudges the LLM to store facts, no heuristic auto-capture
@@ -134,8 +135,7 @@ The `npm install` runs a postinstall hook that auto-rebuilds `better-sqlite3` fr
 
 | Node | Status |
 |---|---|
-| 22.x – 25.x | Supported. Prebuilt `better-sqlite3` binaries available; postinstall is a no-op. |
-| 26.x | **Not supported yet.** `better-sqlite3` (latest 12.9.0) doesn't compile against Node 26's V8 API (`GetPrototype`/`GetIsolate`/`PropertyCallbackInfo::This` removed). Tracking upstream: [WiseLibs/better-sqlite3](https://github.com/WiseLibs/better-sqlite3). Pin OpenClaw's runtime to Node ≤ 25 until a compatible version ships, OR memex's switch to `node:sqlite` lands. If memex registers under Node 26, you'll see `documents: disabled (initialization failed — common cause: better-sqlite3 native binding missing for this Node version)` in the gateway log — that's this issue. |
+| 22.x – 26.x | Supported. `better-sqlite3` ^12.11.1 includes Node 26 V8 API compatibility. Prebuilt binaries available; postinstall is a no-op. |
 
 Add to your OpenClaw config:
 
@@ -208,6 +208,7 @@ memex (kind: "memory")
 │   ├── Z-score fusion (0.8 vec + 0.2 BM25)
 │   ├── Max-sim chunked embedding
 │   ├── Cross-encoder reranking (optional)
+│   ├── LLM-based reranking (optional, via ordering prompt)
 │   ├── Tag-intersection scoping
 │   ├── In-turn recall cache (per-agent-turn dedup)
 │   ├── Rerank-failure fallback → hybrid fusion ranking unchanged (not cosine)
@@ -220,7 +221,7 @@ memex (kind: "memory")
 ├── Embedding + Rerank Clients
 │   ├── OpenAI-compatible HTTP client
 │   ├── LRU cache (256 entries, 30min TTL)
-│   ├── Transient-failure retry (502/503/504/AbortError, exponential backoff)
+│   ├── Transient-failure retry (500/502/503/504/AbortError, exponential backoff)
 │   └── Auto-chunking for long documents
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,8 +12,9 @@ metadata:
 
 | System | Memory E2E Accuracy | Reader LLM |
 |---|---|---|
+| **Memex (Qwen3-Reranker)** | **94.0%** | GPT-4o |
 | Hindsight/TEMPR | 91.4% | GPT-4o |
-| **Memex** | **90%** | GPT-4o |
+| Memex (no reranker) | 90.0% | GPT-4o |
 | Zep/Graphiti | ~85% | GPT-4o |
 | mem0 | ~78% | GPT-4o |
 | MemGPT | ~75% | GPT-4o |
@@ -98,7 +99,13 @@ openclaw config set plugins.entries.memex.config.documents.reindexIntervalMinute
 Cross-encoder reranker. Off by default. Recommended when `autoRecallLimit=1`.
 
 ```bash
-openclaw config set plugins.entries.memex.config.reranker '{"enabled":true,"endpoint":"http://localhost:8090/v1/rerank","model":"Qwen3-Reranker-0.6B-Q8_0"}'
+openclaw config set plugins.entries.memex.config.reranker '{"enabled":true,"endpoint":"http://<rerank-host>:8090/v1/rerank","model":"Qwen3-Reranker-0.6B-Q8_0"}'
+```
+
+LLM-based reranker (opt-in, higher quality). Set `MEMEX_RERANK_LLM_MODEL` to activate.
+
+```bash
+export MEMEX_RERANK_LLM_MODEL="deepseek-v4-flash"
 ```
 
 ## All Settings

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # Benchmarks — memex
 
-**Updated:** 2026-04-11
+**Updated:** 2026-07-11
 
 ## Environment
 
@@ -8,7 +8,7 @@
 |---|---|
 | Test host | Ubuntu, Xeon CPU, 16GB RAM, Node 25.9 |
 | Embedding | Qwen3-Embedding-4B-Q8_0 (2560d) via llama-swap on a dedicated Apple Silicon host |
-| Reranker | **Qwen3-Reranker-0.6B-Q8_0** via same endpoint (upgraded 2026-04-10, replaced bge-reranker-v2-m3-Q8_0) |
+| Reranker | Cross-encoder: **Qwen3-Reranker-0.6B-Q8_0** via same endpoint (upgraded 2026-04-10, replaced bge-reranker-v2-m3-Q8_0). LLM reranker also available (opt-in via `MEMEX_RERANK_LLM_MODEL`, ordering-based, e.g. deepseek-v4-flash). |
 | Network | Test host → inference host via Tailscale (~3-90ms RTT) |
 | Database | SQLite + sqlite-vec + FTS5 |
 | Memories | ~2100 entries (avg 94 chars, max 650 chars) |
@@ -82,6 +82,20 @@ Embedding API call dominates. Local compute (SQLite, fusion) is negligible.
 
 ---
 
+## Domain Eval (Recall Quality)
+
+Production recall-quality benchmark against live memex DB. 26 entity-rich queries, Wilson 95% confidence intervals. Measured via `tests/domain-eval.ts`.
+
+| Config | Accuracy | Notes |
+|---|---|---|
+| Baseline (no reranker) | 69% | Hybrid retrieval only |
+| Cross-encoder (Qwen3-Reranker-0.6B) | 77% | Standard reranker |
+| LLM reranker (deepseek-v4-flash) | **85%** | Ordering-based, opt-in via `MEMEX_RERANK_LLM_MODEL` |
+
+The LLM reranker adds ~1-2s latency but is the strongest option for quality. Cross-encoder is the default (fast, local). See `docs/design/recall-quality-design.md` for the canonical spec.
+
+---
+
 ## Issue #7 Production Recall Test
 
 9 queries against known facts from conversations.
@@ -121,6 +135,10 @@ TIER=fast node --import jiti/register tests/fast-benchmark.ts
 TIER=fast RERANK=1 RERANK_ENDPOINT=... RERANK_MODEL=Qwen3-Reranker-0.6B-Q8_0 RERANK_API_KEY=... \
   node --import jiti/register tests/fast-benchmark.ts
 
+# LongMemEval fast benchmark with LLM reranker
+TIER=fast RERANK=llm MEMEX_RERANK_LLM_MODEL=deepseek/deepseek-v4-flash \
+  node --import jiti/register tests/fast-benchmark.ts
+
 # LongMemEval E2E benchmark with fresh GPT-4o generation (~4min, OpenAI cost)
 TIER=e2e RERANK=1 LLM_API_KEY=... OPENAI_API_KEY=... \
   node --import jiti/register tests/fast-benchmark.ts
@@ -137,4 +155,21 @@ BEIR_MODE=hybrid EMBED_BASE_URL=... EMBED_MODEL=... node --import jiti/register 
 
 # Latency benchmark
 node --import jiti/register tests/benchmark.ts
+
+# Domain eval (26 queries, Wilson 95% CI) — baseline
+EVAL_DB=~/.openclaw/memory/memex/memex.sqlite \
+  EMBED_BASE_URL=... EMBED_API_KEY=... EMBED_MODEL=... \
+  node --import jiti/register tests/domain-eval.ts
+
+# Domain eval — cross-encoder rerank
+EVAL_DB=~/.openclaw/memory/memex/memex.sqlite \
+  EMBED_BASE_URL=... EMBED_API_KEY=... EMBED_MODEL=... \
+  RERANK=cross-encoder RERANK_ENDPOINT=... RERANK_MODEL=... RERANK_API_KEY=... \
+  node --import jiti/register tests/domain-eval.ts
+
+# Domain eval — LLM rerank
+EVAL_DB=~/.openclaw/memory/memex/memex.sqlite \
+  EMBED_BASE_URL=... EMBED_API_KEY=... EMBED_MODEL=... \
+  RERANK=llm MEMEX_RERANK_LLM_MODEL=deepseek/deepseek-v4-flash \
+  node --import jiti/register tests/domain-eval.ts
 ```

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -15,7 +15,7 @@ memex was built by merging and rewriting two open-source projects. Here's what c
 | **Processes** | 2 (MCP server + plugin) | 1 | **1** |
 | **Section-level FTS** | No | No | **Yes (heading + bullet splitting)** |
 | **Embedding model tracking** | No | No | **Yes (detect changes, warn user)** |
-| **Session import (LLM)** | No | No | **Yes (Gemini extraction)** |
+| **Session import (LLM)** | No | No | **Yes (configurable LLM extraction)** |
 | **Durability-aware decay** | No | Single half-life | **Per-type (permanent/transient/ephemeral)** |
 | **Tests** | ~50 | ~80 | **506** |
 
@@ -24,7 +24,7 @@ memex was built by merging and rewriting two open-source projects. Here's what c
 |  | **memex** | mem0 | Zep/Graphiti | MemGPT/Letta |
 |---|---|---|---|---|
 | **Architecture** | SQLite + local models | Cloud API | Neo4j graph DB | LLM-managed paging |
-| **Latency (p50)** | ~130ms | ~200ms¹ | ~300ms¹ | ~500ms+¹ |
+| **Latency (p50)** | ~130ms (no rerank), ~1050ms (cross-enc), ~1-2s (LLM rerank) | ~200ms¹ | ~300ms¹ | ~500ms+¹ |
 | **Memory** | 13MB heap | Cloud (N/A) | 500MB+ (Neo4j) | Varies |
 | **Cost per query** | $0 (local inference) | ~$0.01 (API) | Self-host | LLM token cost |
 | **Offline capable** | Yes | No | Partial | No |
@@ -102,6 +102,8 @@ Measured on LongMemEval_s (ICLR 2025). N=50 for memex, published numbers for oth
 Evaluated using official LongMemEval prompts and GPT-4o-mini LLM-judge (same methodology as published systems). Numbers from `tests/fast-benchmark.ts` with chunked embeddings. The Qwen3-Reranker variant is the current production configuration (upgraded 2026-04-10); the "no reranker" row is kept for comparison because the reranker adds meaningful latency. In production memex returns ≤3 results, making R@3 the most relevant retrieval metric.
 
 N=50 is small enough that a ±2 query swing is within noise. The reranker improvement was reproduced independently on two runs and is supported by a mechanistic argument (Qwen3-Reranker has 32K context vs bge-reranker-v2-m3's 8K-truncation on long chunked sessions — see `docs/research/embed-rerank-upgrade-brief.md`).
+
+In addition to the cross-encoder, an **LLM-based ordering reranker** is available (opt-in via `MEMEX_RERANK_LLM_MODEL`). On the domain-eval benchmark (26 queries, Wilson 95% CI), it achieves **85% accuracy** vs 77% for the cross-encoder and 69% baseline (no reranker). The LLM reranker adds ~1-2s latency and is best suited when quality matters more than speed. See `docs/design/recall-quality-design.md` for the canonical spec.
 
 ## Performance Profile
 

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -35,7 +35,7 @@ graph TB
 
 ## 1. Capture Pipeline (Auto-Capture)
 
-**Trigger:** `agent_end` event — fires after every agent conversation turn.
+**Trigger:** Hook fires after every agent conversation turn.
 
 ```mermaid
 flowchart TD
@@ -140,11 +140,11 @@ we don't want to burn tokens on embedding every message
 
 ### 2a. Auto-Recall (Injected Context)
 
-**Trigger:** `agent_start` event — fires before every agent conversation turn.
+**Trigger:** `before_prompt_build` hook — fires before the agent processes a turn.
 
 ```mermaid
 flowchart TD
-    A["agent_start event"] --> B["Extract query from<br/>last user message"]
+    A["before_prompt_build hook"] --> B["Extract query from<br/>last user message"]
     B --> C{"shouldSkipRetrieval()"}
 
     C -->|"Greeting / command / affirmation<br/>short text / HEARTBEAT"| SKIP["Return — no injection"]
@@ -195,9 +195,9 @@ flowchart TD
         BM["BM25 Search<br/>(keyword FTS5)<br/>weight: 0.3"]
     end
 
-    S1 --> S2["Stage 2 — RRF Fusion<br/>Both hit: vectorScore + 15% BM25 boost<br/>Vector only: vectorScore<br/>BM25 only: bm25Score (validate exists)<br/>Ghost entry detection"]
+    S1 --> S2["Stage 2 — Score Fusion (weighted/z-score)<br/>Both hit: vectorScore + 15% BM25 boost<br/>Vector only: vectorScore<br/>BM25 only: bm25Score (validate exists)<br/>Ghost entry detection"]
 
-    S2 --> S3["Stage 3 — Rerank (cross-encoder)<br/>80% reranker + 20% fused score<br/>Timeout: 5s, fallback: cosine sim<br/>Provider: Jina / SiliconFlow / Voyage / Pinecone"]
+    S2 --> S3["Stage 3 — Rerank (cross-encoder or LLM)<br/>Configurable blend with fusion score<br/>Timeout: 15s, fallback: hybrid ranking<br/>Cross-encoder: Jina / SiliconFlow / Voyage / Pinecone<br/>LLM: ordering-based (opt-in via env)"]
 
     S3 --> S4["Stage 4 — Recency Boost<br/>boost = exp(-ageDays / 14) * 0.10<br/>Today: +0.10 | 7d: +0.06 | 14d: +0.04 | 30d: +0.01"]
 
@@ -205,7 +205,7 @@ flowchart TD
 
     S5 --> S6["Stage 6 — Time Decay + Length Norm<br/>Decay: 0.5 + 0.5 * exp(-age/60), floor 0.5x<br/>Length: 1 / (1 + 0.5 * log2(len/500))"]
 
-    S6 --> S7["Stage 7 — Hard Cutoff + Noise + MMR<br/>hardMinScore: 0.40<br/>Noise filter (denials, boilerplate)<br/>MMR: cosine > 0.85 → defer duplicate"]
+    S6 --> S7["Stage 7 — Hard Cutoff + Noise + MMR<br/>hardMinScore: 0.15 (adaptive)<br/>Noise filter (denials, boilerplate)<br/>MMR: cosine > 0.85 → defer duplicate"]
 
     S7 --> OUT["Return top-k results"]
 
@@ -231,7 +231,7 @@ flowchart TD
 | 4. Recency | "Switched to Qwen3-Embedding" (2 days old) gets +0.09 | 0.78 -> 0.87 |
 | 5. Importance | Same entry has importance=0.8, factor x0.94 | 0.87 -> 0.82 |
 | 6. Decay/Len | 3-day old, 45 chars, minimal penalties | 0.82 -> 0.81 |
-| 7. Cutoff | All above 0.40 survive; MMR defers duplicate phrasing | 5 results returned |
+| 7. Cutoff | All above 0.15 survive; MMR defers duplicate phrasing | 5 results returned |
 
 ---
 
@@ -300,7 +300,8 @@ gantt
 | Vector search (sqlite-vec) | ~33ms | CPU (SIMD) |
 | BM25 search (FTS5) | ~14ms | CPU (index) |
 | Rerank (5 docs, cross-encoder) | ~53ms | Network I/O |
-| Full hybrid+rerank pipeline | ~250ms | Mixed |
+| Rerank (LLM, ordering-based) | ~1-2s | Network I/O (LLM inference) |
+| Full hybrid+rerank pipeline (cross-enc) | ~250ms | Mixed |
 | Unified recall (both sources) | ~300-400ms | Mixed |
 
 ---
@@ -324,7 +325,7 @@ graph LR
 {
   id: string;          // UUID
   text: string;        // The memory content
-  vector: number[];    // 1024-dim embedding (Qwen3-Embedding)
+  vector: number[];    // Embedding dimensions (varies by model; e.g. Qwen3-Embedding-4B = 2560d, 0.6B = 1024d)
   importance: number;  // 0.0-1.0 (set by heuristic at capture)
   category: string;    // "preference" | "fact" | "decision" | "entity" | "other"
   scope: string;       // "global" | "agent:<id>" | "session:<id>"
@@ -341,16 +342,12 @@ Key config knobs that affect the pipeline:
 | Config | Default | Effect |
 |--------|---------|--------|
 | `autoCapture` | true | Enable/disable auto-capture pipeline |
-| `captureAssistant` | false | Also capture assistant messages |
-| `captureMinImportance` | 0.5 | Heuristic score threshold |
+| `autoCapture` | true | Enable/disable auto-capture pipeline |
+| `autoRecall` | true | Enable/disable auto-recall |
 | `retrieval.mode` | "hybrid" | "hybrid" or "vector" only |
-| `retrieval.rerank` | "cross-encoder" | "cross-encoder", "lightweight", "none" |
-| `retrieval.hardMinScore` | 0.40 | Post-pipeline score cutoff |
-| `retrieval.recencyHalfLifeDays` | 14 | Recency boost decay rate |
+| `retrieval.rerank` | "cross-encoder" | "cross-encoder", "llm", "lightweight", "none" |
+| `retrieval.hardMinScore` | 0.15 | Post-pipeline score cutoff (adaptive; override via `MEMEX_HARD_MIN_SCORE_OVERRIDE`) |
 | `retrieval.timeDecayHalfLifeDays` | 60 | Staleness penalty rate |
-| `retrieval.lengthNormAnchor` | 500 | Length penalty reference |
-| `unifiedRecall.crossRerank` | false | Cross-source reranking |
-| `unifiedRecall.earlyTermination` | false | Skip docs when memories are strong |
 
 ---
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,8 +1,8 @@
 # Unified Memory System — Requirements
 
 **Project:** `memex`
-**Status:** Complete — 506+ tests passing, benchmarks stable, ready for deployment
-**Updated:** 2026-03-15
+**Status:** Active — 905+ tests passing, benchmarks stable, MCP server deployed
+**Updated:** 2026-07-11
 
 ---
 
@@ -59,11 +59,11 @@ memex (OpenClaw plugin, kind: "memory")
 
 ## Key Source Files
 
-- `src/store.ts` — SQLite storage (vector + BM25 + CRUD for conversation memories)
+- `src/memory.ts` — SQLite storage (vector + BM25 + CRUD for conversation memories)
 - `src/search.ts` — Document search functions (index, query, hybrid search)
 - `src/llm.ts` — OpenAI-compat embedding + reranking + query expansion
-- `src/retriever.ts` — 7-stage retrieval pipeline + rerank utils
-- `src/unified-recall.ts` — Fan-out, normalize, merge, cross-rerank
+- `src/retriever.ts` — Retrieval pipeline + rerank utils (cross-encoder + LLM)
+- `src/unified-retriever.ts` — Fan-out, normalize, merge, cross-rerank
 - `src/doc-indexer.ts` — Document indexer (startup + periodic re-index)
 - `src/embedder.ts` — Shared embedding client + LRU cache
 
@@ -77,10 +77,9 @@ const client = new OpenAI({ baseURL: config.embedding.baseURL, apiKey: config.em
 const resp = await client.embeddings.create({ model: config.embedding.model, input: text });
 ```
 
-Query expansion (HyDE) uses LLM generation via the chat endpoint:
-- Configurable model (default deployment: Qwen3-0.6B-Instruct on local server)
-- Use `/no_think` prefix or `enable_thinking: false` to disable reasoning overhead
-- Fallback: cloud LLM API or disabled (raw query)
+Query expansion (HyDE) uses LLM generation via the chat endpoint through the configurable `generation` block. Uses the same OpenAI-compatible proxy as embedding and reranking.
+
+Reranking supports two backends: cross-encoder (Qwen3-Reranker-0.6B, default) and LLM-based ordering reranker (opt-in via `MEMEX_RERANK_LLM_MODEL` env var).
 
 ---
 
@@ -96,16 +95,14 @@ Query expansion (HyDE) uses LLM generation via the chat endpoint:
   },
   "reranker": {
     "enabled": true,
-    "endpoint": "http://localhost:<port>/v1/rerank",
-    "apiKey": "unused",
-    "model": "bge-reranker-v2-m3-Q8_0",
+    "endpoint": "https://<proxy-host>/v1/rerank",
+    "apiKey": "<api-key>",
+    "model": "Qwen3-Reranker-0.6B-Q8_0",
     "provider": "jina"
   },
-  "conversation": {
-    "dbPath": "~/.openclaw/memory/memex.db",
-    "autoCapture": true,
-    "autoRecall": false
-  },
+  "dbPath": "~/.openclaw/memory/memex/memex.sqlite",
+  "autoCapture": true,
+  "autoRecall": true,
   "documents": {
     "enabled": true,
     "paths": [
@@ -133,15 +130,16 @@ Query expansion (HyDE) uses LLM generation via the chat endpoint:
 Embedding and reranker models are hot-swappable via config. Switching is a `baseURL` + `model` change.
 
 ### Known Embedding Models
-- `Qwen3-Embedding-4B-Q8_0` — 2560d, local inference ← current default
-- `Qwen3-Embedding-0.6B-Q8_0` — 1024d, local inference
+- `Qwen3-Embedding-4B-Q8_0` — 2560d, local inference ← production default
+- `Qwen3-Embedding-0.6B-Q8_0` — 1024d, local inference ← code default
 - `gemini-embedding-001` — 3072d, Gemini API, ~250ms
 - `stella_en_1.5B_v5` — 1536d, local, MTEB 71.19 (best under 2B)
 
 ### Known Reranker Models
-- `bge-reranker-v2-m3-Q8_0` — local inference, ~61ms ← current
+- `Qwen3-Reranker-0.6B-Q8_0` — local cross-encoder, 32K context ← current default
 - `jina-reranker-v3` — API, BEIR 61.9
 - `gte-reranker-modernbert-base` — local, 149M params, smallest
+- LLM reranker (ordering-based, e.g. deepseek-v4-flash) — opt-in via `MEMEX_RERANK_LLM_MODEL`
 
 ### Re-embedding on Model Switch
 - CLI: `memex rebuild --all`
@@ -151,34 +149,37 @@ Embedding and reranker models are hot-swappable via config. Switching is a `base
 
 ## Local Inference
 
-**Running:** <model-server> on <port>, managed by a service unit
+**Running:** llama.cpp server via systemd, managed by `<model-server>` on Tailscale.
 - Qwen3-Embedding-4B-Q8_0 — embedding, 2560 dims (configurable)
-- bge-reranker-v2-m3-Q8_0 (606MB) — reranking
-- Qwen3-0.6B-Instruct-Q8_0 (767MB) — chat/query expansion
+- Qwen3-Reranker-0.6B-Q8_0 — cross-encoder reranking
+- Configurable LLM for query expansion and generation
 
-**Config:** `<config-path>`
-- `groups.inference.swap: false` — keeps all 3 models loaded simultaneously
-- `--batch-size 8192 --ubatch-size 8192` on embedding + reranker (avoids "too large to process")
-- Dynamic ports via `${PORT}` macro (5800, 5801, 5802)
-- All preloaded on startup
-
-**~3.5GB VRAM** of 12.7GB, ~9GB headroom for TTS + future models
-**Config repo:** `github.com/example/config` (private)
+**Config:** private config repo
+- `groups.inference.swap: false` — keeps all models loaded simultaneously
+- `--batch-size 8192 --ubatch-size 8192` to avoid "too large to process" errors
+- All models preloaded on startup
 
 ---
 
 ## CLI Commands
 
+CLI commands run through the OpenClaw plugin system (`openclaw memex <command>`) or via the `memex-mcp` binary for the MCP server.
+
 | Command | Description |
 |---------|-------------|
 | `memex import` | Bulk-import past sessions as memories |
-| `memex rebuild` | Re-embed and reindex all data (replaces re-embed/reindex; also cleans noise) |
+| `memex rebuild` | Re-embed and reindex all data (also cleans noise) |
 | `memex wipe` | Purge all data from the database |
+| `memex stats` | Show memory pool statistics |
+| `memex dream` | Run memory consolidation (dedup, noise removal, reflection) |
+| `memex search [query]` | Search memories and documents |
+| `memex-mcp` | Start standalone MCP server (HTTP or stdio transport) |
 
 ---
 
 ## Non-Goals
 
-- MCP server / HTTP API
 - Multi-machine sync
 - PDF / non-markdown indexing
+
+Note: An MCP server with HTTP transport now exists (`src/mcp-server.ts`, `memex-mcp` bin) — this was promoted from non-goal to shipped feature in v0.7.0.

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -1,8 +1,8 @@
 # Research Notes — Unified Memory System
 
-**Note:** This document reflects the research phase. The architecture has since been consolidated to a single SQLite database with unified retriever pipeline. See CLAUDE.md for current architecture.
+**Note:** This document reflects the research phase (2026-03). The architecture has since been consolidated to a single SQLite database with unified retriever pipeline. Reranking is now a core feature (cross-encoder + LLM reranker). The production embedding model is Qwen3-Embedding-4B (not 0.6B). See CLAUDE.md and `docs/design/recall-quality-design.md` for current architecture and quality baselines.
 
-**Updated:** 2026-03-05
+**Updated:** 2026-07-11 (staleness review — content preserved as historical record)
 
 ---
 
@@ -39,17 +39,17 @@
 | Ollama | ✅ | ✅ | ❌ no endpoint | ✅ one port | brew | Same as llama.cpp |
 | LocalAI | ✅ | ✅ | ✅ Python backend | ✅ one port | Docker/native | Same as llama.cpp + Python overhead |
 
-**Decision:** <model-server>. Go binary, manages llama-server child processes, proper HTTP reverse proxy, health monitoring, web UI. One port, zero deps. Router mode was tried first but abandoned (child processes crash after 2 requests, never respawn).
+**Decision:** llama.cpp with a Go reverse-proxy manager. Go binary manages llama-server child processes, proper HTTP reverse proxy, health monitoring, web UI. One port, zero deps. Router mode was tried first but abandoned (child processes crash after 2 requests, never respawn).
 
-### <model-server> Setup
+### Model Server Setup
 - Go binary at `<binary-path>`, config at `<config-path>`
 - `groups.inference.swap: false` keeps all models loaded simultaneously (default `swap: true` would hot-swap)
 - `--batch-size 8192 --ubatch-size 8192` on embedding + reranker (avoids "too large to process" for large docs)
-- Dynamic ports via `${PORT}` macro (embedding, reranker, chat each on their own port)
+- Dynamic ports via `${PORT}` macro
 - Preload hooks load all models on startup
-- service manager: `<service-unit>` (RunAtLoad, KeepAlive)
+- service manager: systemd (RunAtLoad, KeepAlive)
 - Current setup on the always-on host: 3 models, on a single port
-- Config tracked in `github.com/example/config` (private)
+- Config tracked in private config repo
 
 ### mlx-openai-server Potential
 - 244 stars, actively maintained (as of Mar 2026)
@@ -105,7 +105,7 @@ vs current (Gemini, no reranker): ~350ms
 
 1. **Embedding is the bottleneck.** LanceDB search is <30ms. Switching to local drops embed from 250ms to 45ms.
 2. **Quality gap doesn't matter at our scale.** With <100 memories, MTEB 64.3 vs 68.3 returns identical top-5 results.
-3. **Reranking is new capability.** Currently disabled. Local reranker at 61ms is essentially free to add.
+3. **Reranking is now a core feature.** Cross-encoder (Qwen3-Reranker-0.6B) is the default; LLM-based ordering reranker is opt-in. Both are wired into the MCP and plugin paths.
 4. **The always-on host has headroom.** Using ~3.5GB of 12.7GB VRAM. TTS already running, ~8-9GB available.
 5. **Model swapping is config-only.** Plugin uses OpenAI-compat API — change baseURL + model name to switch.
 

--- a/docs/RESILIENCY.md
+++ b/docs/RESILIENCY.md
@@ -197,8 +197,8 @@ The `UnifiedRetriever` (src/unified-retriever.ts) replaces the dual-pipeline arc
 | Embed query | API timeout | No vector search | BM25-only results (degraded but functional) |
 | Memory search | SQLite error | No memory results | Document results only |
 | Document search | SQLite error | No doc results | Memory results only |
-| Reranking | API timeout (10s) | Skip reranking | Calibrated scores pass through (slightly lower quality) |
-| Reranking | Model swap timeout | Same as above | Same — confidence gate may skip future reranks |
+| Reranking | API timeout (15s) | Skip reranking | Calibrated scores pass through (slightly lower quality) |
+| Reranking | Model swap timeout | Same as above | Same — confidence gate may skip future reranks (transient-retry with 4 attempts) |
 
 ### Confidence gate
 

--- a/docs/deploy/container.md
+++ b/docs/deploy/container.md
@@ -8,10 +8,10 @@ transfer workflow described in `docs/plans/019-containerize-memex.md`.
 
 ## What's in the image
 
-- **Runtime:** `node:25-slim`. Node is pinned to the 25 series because Node 26
-  breaks `better-sqlite3`'s prebuilt native binding (see
-  `reference-node-26-better-sqlite3-blocker`). Bump to `node:26-slim` once
-  upstream ships Node-26 prebuilds.
+- **Runtime:** `node:25-slim`. Previously pinned to 25 because Node 26 broke
+  `better-sqlite3`'s prebuilt native binding. `better-sqlite3` has been bumped
+  to 12.x (Node-26-compatible), clearing that blocker. Bump to `node:26-slim`
+  when convenient.
 - **Artifact:** pre-compiled `dist/` (multi-stage `tsc` build) — smaller image,
   fast startup. The daemon entrypoint is `node dist/src/mcp-server.js`.
 - **Native deps:** `better-sqlite3` + `sqlite-vec`, rebuilt for the runtime ABI
@@ -22,7 +22,7 @@ transfer workflow described in `docs/plans/019-containerize-memex.md`.
 ## Build
 
 ```bash
-docker build -t memex-daemon:0.7 .
+docker build -t memex-daemon:0.7.3 .
 ```
 
 ## Configure
@@ -34,10 +34,13 @@ or the repo). All values are env-driven:
 | Var | Purpose |
 |-----|---------|
 | `MEMEX_EMBED_ENDPOINT` / `_API_KEY` / `_MODEL` / `_DIM` | Embedding server (OpenAI-compatible). Omit → BM25-only. |
-| `MEMEX_LLM_ENDPOINT` / `_MODEL` / `_API_KEY` | Reflection LLM. Omit → reflection skipped. |
+| `MEMEX_RERANK_ENDPOINT` / `_API_KEY` / `_MODEL` | Cross-encoder reranker (Qwen3-Reranker-0.6B). Omit → no reranking. |
+| `MEMEX_LLM_ENDPOINT` / `_MODEL` / `_API_KEY` | Reflection LLM + LLM reranker (shared endpoint). Omit → reflection skipped, no LLM reranker. |
+| `MEMEX_RERANK_LLM_MODEL` | LLM-based reranker model (opt-in). Requires `MEMEX_LLM_ENDPOINT`. |
 | `MEMEX_AUTH_TOKEN` | Bearer token clients must send. **Set in production.** |
 | `MEMEX_HTTP_HOST` / `_PORT` | Bind. Inside a container use `0.0.0.0`. |
 | `MEMEX_DB_PATH` | SQLite path. Defaults to `/data/memex.sqlite`. |
+| `MEMEX_CLIENT_NAME` | Client identity for scope visibility (e.g. `claude-code`). |
 
 ## Run
 
@@ -57,7 +60,7 @@ docker run -d --name memex-daemon --network host \
   --env-file memex.env \
   -v memex-data:/data \
   --restart unless-stopped \
-  memex-daemon:0.7
+  memex-daemon:0.7.3
 ```
 
 ## DB persistence

--- a/docs/design/archive/feedback-loop.md
+++ b/docs/design/archive/feedback-loop.md
@@ -1,5 +1,6 @@
 # Feedback Loop — Bounded Recall-Frequency Boost (design)
 
+**Superseded by:** [recall-quality-design.md](../recall-quality-design.md) — canonical spec.
 **Status:** design-only (ready for TDD implementation). No code changes in this doc.
 **Date:** 2026-06-29
 **Roadmap item:** "Feedback loop — implicit recall-frequency boost (bounded)."

--- a/docs/design/archive/recall-validation-analysis-revised.md
+++ b/docs/design/archive/recall-validation-analysis-revised.md
@@ -1,5 +1,6 @@
 # Memex Recall Validation: Gaps, Criteria, and Improvement Plan
 
+**Superseded by:** [recall-quality-design.md](../recall-quality-design.md) — canonical spec.
 **Status:** REVISED (iteration 3 -- addresses 16 critique points from third adversarial review: 7 critical, 6 major, 3 minor). All claims cite file:line sources verified 2026-07-01. Target audience: engineering team that owns the eval and retrieval pipelines.
 
 ---

--- a/docs/design/archive/retrieval-redesign.md
+++ b/docs/design/archive/retrieval-redesign.md
@@ -1,5 +1,6 @@
 # memex Retrieval Redesign — Noise-Robust Hybrid Recall
 
+**Superseded by:** [recall-quality-design.md](../recall-quality-design.md) — canonical spec.
 **Status:** design proposal (not implemented) · **Date:** 2026-06-29
 **Goal:** make recall **store-invariant** — return the one relevant memory (or none) regardless of how polluted the store is.
 

--- a/docs/design/claude-code-integration.md
+++ b/docs/design/claude-code-integration.md
@@ -1,7 +1,7 @@
 # Claude Code Integration — Use Cases & Constraints
 
-**Date:** 2026-04-13
-**Status:** Brainstorm — needs user input on direction
+**Date:** 2026-04-13 · **Updated:** 2026-07-11
+**Status:** Brainstorm — many questions resolved by v0.7.x implementation. Notes below reflect current state.
 
 ---
 
@@ -17,9 +17,10 @@ What should the experience be? What problems does memex solve for Claude Code us
 | File search | Grep, Glob, Read | Nothing — Claude Code is better at this |
 | Project context | CLAUDE.md (one file) | Could add structured memory per project |
 | Cross-session memory | None — each session starts fresh | Persistent memory across sessions |
-| User preferences | CLAUDE.md (manual) | Auto-learned preferences |
-| Codebase knowledge | Reads files on demand | Indexed, searchable knowledge base |
-| Session history | Conversation compaction | Extracted learnings from past sessions |
+| User preferences | CLAUDE.md (manual) | Auto-learned preferences (auto-capture in OpenClaw; explicit memory_store in Claude Code) |
+| Codebase knowledge | Reads files on demand | Indexed, searchable knowledge base (document_search) |
+| Session history | Conversation compaction | Extracted learnings from past sessions (dreaming reflection) |
+| Project isolation | None — CLAUDE.md is per-project but flat | Multi-valued scope tags with server-authoritative derivation |
 
 **The gap Claude Code has:** No memory between sessions. Every conversation starts cold. CLAUDE.md helps but is manually maintained and limited to one file.
 
@@ -30,12 +31,14 @@ What should the experience be? What problems does memex solve for Claude Code us
 - Store facts, preferences, decisions during conversation
 - Recall them in future conversations
 - **This works today** via memory_store + memory_recall MCP tools
+- **Implemented:** MCP tools available in Claude Code via .mcp.json (stdio or HTTP transport)
+- **Reranking:** Cross-encoder (Qwen3-Reranker-0.6B) and LLM reranker (deepseek-v4-flash) available, env-var gated
 
 ### UC2: Project-scoped memory
 "This project uses pnpm, not npm" / "The API base URL is /api/v2"
 - Memory that's specific to a project, not global
 - Different projects have different conventions
-- **Needs:** per-project DB or scoped memories within shared DB
+- **Implemented:** Scope tags (`memory_scopes` table, `src/scope-derive.ts`). Server-authoritative derivation auto-tags `global` + `project:<git-remote-hash>`. MCP tools accept `scopes`, `agent_id`, `session_id` params. Tag-intersection filtering prevents cross-project leakage. Configurable DB path via `MEMEX_DB_PATH` for per-project isolation.
 
 ### UC3: Codebase indexing
 "What does the auth middleware do?" / "How does the payment flow work?"
@@ -51,7 +54,7 @@ What should the experience be? What problems does memex solve for Claude Code us
 ### UC5: Auto-learning from sessions
 "Remember what we discussed about the API redesign"
 - Extract knowledge from conversation history
-- **Needs:** session extraction (killed for batch, but could work incrementally via auto-capture)
+- **Needs:** The OpenClaw plugin has auto-capture (LLM nudged to call memory_store). Claude Code MCP path relies on explicit memory_store calls from the agent, assisted by MCP server instructions. Dreaming reflection (LLM-based) consolidates stored memories into learnings. No session-extraction pipeline exists for Claude Code standalone.
 
 ## Constraints
 
@@ -83,11 +86,12 @@ What should the experience be? What problems does memex solve for Claude Code us
 - Best quality, simplest code
 - Tradeoff: requires API key, costs money, needs internet
 
-### Option D: Configurable (current)
-- Embedding endpoint is optional
+### Option D: Configurable (current — implemented)
+- Embedding endpoint is optional (OpenAI-compatible API)
 - BM25 fallback when no embedder
 - User brings their own infrastructure
-- Tradeoff: complex setup for full features
+- **Production deployment:** All inference (embed + rerank + LLM) routed through a single llm-proxy. Embed model: qwen3-embedding (Qwen3-Embedding-4B). Reranker: cross-encoder (Qwen3-Reranker-0.6B) and/or LLM reranker (deepseek-v4-flash, opt-in). Server runs as HTTP daemon on a dev host, shared across devices.
+- Tradeoff: complex setup for full features, but one proxy endpoint simplifies configuration
 
 ## DB strategy options
 
@@ -111,11 +115,12 @@ What should the experience be? What problems does memex solve for Claude Code us
 - Pro: best of both worlds
 - Con: complexity, merge logic
 
-### DB-D: Configurable (let user choose)
-- Default: global DB at ~/.memex/memex.sqlite
-- Override: MEMEX_DB_PATH in .mcp.json per project
+### DB-D: Configurable (let user choose) — implemented
+- Default: global DB at `~/.openclaw/memory/memex/memex.sqlite`
+- Override: `MEMEX_DB_PATH` env var or `--db` CLI flag
+- Scope tags provide project isolation within a shared DB (server-authoritative, auto-derived from git remote)
 - User decides per-project vs shared
-- Pro: flexible
+- Pro: flexible, scope tags prevent cross-contamination without separate DBs
 - Con: user has to think about it
 
 ## Relationship to CLAUDE.md
@@ -136,10 +141,10 @@ CLAUDE.md is Claude Code's built-in project context file. Options:
 - Version-controlled, human-auditable
 - Like Mastra's append-only observation log, but as a file
 
-## Questions for user
+## Questions for user — answers as of v0.7.3
 
-1. **Primary use case?** Cross-session memory (UC1), project-scoped (UC2), codebase indexing (UC3), or all?
-2. **Embedding strategy?** Zero-config BM25 (A), bundled model (B), cloud API (C), or configurable (D)?
-3. **DB scope?** Global (DB-A), per-project (DB-B), layered (DB-C), or configurable (DB-D)?
-4. **CLAUDE.md relationship?** Replace (MD-A), complement (MD-B), or generate sections (MD-C)?
-5. **Should memex work for Claude Code users who don't have OpenClaw?** (i.e., standalone product)
+1. **Primary use case?** Cross-session memory (UC1) + project-scoped (UC2). Both work via the same MCP server. Codebase indexing (UC3) is handled by document_search (separate pipeline).
+2. **Embedding strategy?** Configurable (D). Production uses an OpenAI-compatible proxy. BM25 fallback works for zero-config usage.
+3. **DB scope?** Configurable (DB-D). Default global DB at `~/.openclaw/memory/memex/memex.sqlite`. Scope tags prevent cross-project contamination.
+4. **CLAUDE.md relationship?** Complement (MD-B). CLAUDE.md for static project rules, memex for dynamic learned knowledge.
+5. **Should memex work for Claude Code users who don't have OpenClaw?** Yes — the MCP server is standalone. OpenClaw plugin and MCP server share the same DB so users can use both.

--- a/docs/design/dreaming-llm-integration.md
+++ b/docs/design/dreaming-llm-integration.md
@@ -1,5 +1,6 @@
 # Dreaming LLM Integration Design
 
+**Status:** Implemented (shipped v0.7.0, 2026-05-10). LLM reranker added 2026-07-02 reusing the same endpoint + model config (see `src/rerankers/llm-reranker.ts`).
 **Date:** 2026-04-12
 **Project:** Project 3 (Dreaming Reflection) from `docs/plans/02-projects.md`
 **Goal:** Wire an LLM chat endpoint into the MCP server so dreaming reflection runs autonomously.
@@ -38,10 +39,11 @@ fetch(llmConfig.endpoint + "/v1/chat/completions")
 ```
 MEMEX_LLM_ENDPOINT   — base URL (e.g. http://<host>:<port>), /v1/chat/completions appended
 MEMEX_LLM_MODEL      — model name for chat completions
-MEMEX_LLM_API_KEY    — optional, falls back to MEMEX_EMBED_API_KEY, then op://
+MEMEX_LLM_API_KEY    — optional, falls back to MEMEX_EMBED_API_KEY
+MEMEX_LLM_TIMEOUT    — optional, request timeout in ms (default: 120000)
 ```
 
-Same pattern as embedding config. Same inference host, different model.
+Same pattern as embedding config. Same inference host, different model. Also supports CLI flags: `--llm-endpoint`, `--llm-model`, `--llm-api-key`, `--llm-timeout`.
 
 ### Changes
 
@@ -99,6 +101,11 @@ reflectionLLM,
 1. Unit test: `createMemexMcpServer` with reflectionLLM config → dream cycle includes reflection
 2. Unit test: `memory_dream` tool with phase="reflect" → calls reflectionSweep
 3. Production test: run against live DB with real LLM, verify learnings
+
+## Post-implementation additions (v0.7.3)
+
+- **LLM reranker** (`src/rerankers/llm-reranker.ts`, opt-in via `MEMEX_RERANK_LLM_MODEL`) reuses the same `MEMEX_LLM_ENDPOINT` + `reflectionLLM.apiKey`. Uses deepseek-v4-flash for ordering-based relevance ranking. Domain-eval: 85% (vs 69% baseline, 77% cross-encoder).
+- **MEMEX_LLM_TIMEOUT** env var added for configurable request timeouts.
 
 ## Not in scope
 

--- a/docs/design/entity-extraction.md
+++ b/docs/design/entity-extraction.md
@@ -1,5 +1,7 @@
 # Entity Extraction — Design Doc
 
+**Status: Implemented (v0.7.0).** `src/entities.ts`, `src/graph.ts`, and the retriever wiring all exist. Entity boost (`entityBoost`) defaults to **off** — BM25 already captures entity-keyword overlap, and enabling it regresses domain eval (73-75% vs 80% without). The graph traversal path (`entityGraph`) is also off by default (zero measured quality impact on the current 26-query domain eval).
+
 ## Problem
 
 Memex retrieval uses 2 signals: vector similarity + BM25 keywords. Hindsight (91.4%) uses 4 signals including entity graph traversal. The gap is primarily from entity-aware retrieval — when you ask "What's Alex's rule for host-a?", memex relies on vector closeness. Entity overlap as a discrete signal directly boosts memories mentioning the same entities.
@@ -27,10 +29,11 @@ boost = 1 + (overlap_count / query_entity_count) * ENTITY_BOOST_WEIGHT
 ### Pipeline position
 
 ```
-Query → Embed → Vector+BM25 (parallel) → Fuse → ENTITY BOOST → Rerank → Score → Top-K
+Query → Embed → Vector+BM25 (parallel) → Fuse → (ENTITY BOOST, off by default) → Rerank → Score → Top-K
 ```
 
 After fusion, before scoring pipeline. Doesn't change z-score math.
+Entity boost is gated behind `entityBoost: true` in `RetrievalConfig`. Default is off — BM25 already captures entity-keyword overlap, and enabling it regresses domain eval.
 
 ### Backfill
 
@@ -73,8 +76,9 @@ No schema changes. Entities in existing metadata JSON:
 
 | File | Change |
 |---|---|
-| `src/entities.ts` | NEW |
-| `src/memory.ts` | Wire into store/bulkStore |
-| `src/retriever.ts` | applyEntityBoost() |
+| `src/entities.ts` | Implemented |
+| `src/memory.ts` | Wired into store/bulkStore |
+| `src/retriever.ts` | applyEntityBoost() (gated behind `entityBoost` config, off by default) |
+| `src/graph.ts` | Entity graph (link creation + one-hop expansion, off by default) |
 | `src/dreaming.ts` | Eviction threshold |
 | `index.ts` | agentId passthrough |

--- a/docs/design/entity-graph.md
+++ b/docs/design/entity-graph.md
@@ -1,5 +1,7 @@
 # Entity Graph — Design Doc
 
+**Status: Implemented (v0.7.0).** `src/graph.ts` exists with `createLinks()`, `expandOneHop()`, `deleteLinks()`. Wired into `src/memory.ts` (store-time link creation) and `src/retriever.ts` (retrieval-time one-hop expansion). However, `entityGraph` defaults to **off** — measured zero quality impact on the current 26-query domain eval (BM25 + rerank already capture the same signal). Domain eval baseline is 69% (no rerank), 77% (cross-encoder), 85% (LLM reranker) on Wilson CI; graph expansion does not improve these.
+
 ## Problem
 
 Entity boost as a score multiplier doesn't work — BM25 already captures keyword entity matching. Tuning showed it hurts ranking (80% without boost vs 73% with).
@@ -62,27 +64,31 @@ Graph traversal surfaces the *related but different* memory that keyword matchin
 | Schema migration on existing DB | Startup delay | New table, no ALTER — instant |
 | Orphaned links after memory deletion | Dead links | ON DELETE CASCADE handles it |
 
-## Open Questions (for user)
+## Open Questions
 
 1. Should graph expansion only run for `memory_recall` tool, or also for auto-recall? Auto-recall is latency-sensitive (~150ms budget).
+   **Resolved: off by default for both.** Measured zero quality impact on domain eval — BM25 + rerank already capture the signal.
 2. Should dreaming maintain links (relink after dedup/eviction)?
 3. Cap on links per memory — 10? 20?
+   **Resolved: 10** (MAX_LINKS_PER_MEMORY in src/graph.ts).
 
 ## Metrics
 
 | Metric | Baseline (no graph) | Target |
 |---|---|---|
-| Domain eval | 12/15 (80%) | ≥14/15 (93%) |
-| Multi-entity queries | 1/3 (33%) | ≥3/3 (100%) |
+| Domain eval | 18/26 (69%, Wilson CI) | N/A — graph off by default |
+| Multi-entity queries | 2/3 (67%, old 15-query set) | N/A |
 | LongMemEval R@3 | 90% | ≥90% (no regression) |
 | Retrieval latency | ~150ms | <200ms (one-hop adds ~10ms) |
+
+Note: domain eval expanded from 15 to 26 queries (2026-07-02). The original 12/15 (80%) metric was measured before the query set expansion. Graph expansion is disabled by default — BM25 + rerank already capture the same entity-overlap signal.
 
 ## Files
 
 | File | Change |
 |---|---|
-| `src/graph.ts` | **NEW** — createLinks(), expandByLinks() |
-| `src/memory.ts` | Create links table, call createLinks on store |
-| `src/retriever.ts` | Call expandByLinks after fusion |
-| `tests/acceptance-entity-graph.test.ts` | **NEW** |
-| `tests/graph.test.ts` | **NEW** |
+| `src/graph.ts` | Implemented — createLinks(), expandByLinks() |
+| `src/memory.ts` | Links table created, createLinks called on store |
+| `src/retriever.ts` | expandByLinks after fusion (gated behind `entityGraph` config, off by default) |
+| `tests/acceptance-entity-graph.test.ts` | Acceptance tests |
+| `tests/graph.test.ts` | Unit tests |

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -1,34 +1,36 @@
 # MCP Server Design
 
-**Date:** 2026-04-12
+**Date:** 2026-04-12 · **Updated:** 2026-07-11
 **Project:** Project 2 from `docs/plans/02-projects.md`
-**Goal:** Memex as a standalone, always-on memory server via MCP (stdio transport)
+**Goal:** Memex as a standalone, always-on memory server via MCP (stdio + HTTP transports)
 
 ---
 
 ## Architecture
 
 ```
-┌─────────────────┐     stdio      ┌──────────────────────┐
-│  Claude Code    │ ◄────────────► │  memex-mcp-server    │
-│  Cursor / Zed   │    JSON-RPC    │                      │
-│  Any MCP client │                │  ┌────────────────┐  │
-└─────────────────┘                │  │ MemoryStore     │  │
-                                   │  │ (shared SQLite) │  │
-┌─────────────────┐                │  └────────────────┘  │
-│  OpenClaw       │ ◄── same DB ──►│                      │
-│  (plugin path)  │                │  ┌────────────────┐  │
-└─────────────────┘                │  │ Dream timer     │  │
-                                   │  │ (setInterval)   │  │
-                                   │  └────────────────┘  │
-                                   └──────────────────────┘
+┌─────────────────┐     stdio/HTTP  ┌──────────────────────┐
+│  Claude Code    │ ◄─────────────► │  memex-mcp-server    │
+│  Cursor / Zed   │    JSON-RPC     │                      │
+│  Any MCP client │                 │  ┌────────────────┐  │
+└─────────────────┘                 │  │ MemoryStore     │  │
+                                    │  │ (shared SQLite) │  │
+┌─────────────────┐                 │  └────────────────┘  │
+│  OpenClaw       │ ◄── same DB ──► │                      │
+│  (plugin path)  │                 │  ┌────────────────┐  │
+└─────────────────┘                 │  │ Dream timer     │  │
+                                    │  │ (setInterval)   │  │
+                                    │  └────────────────┘  │
+                                    └──────────────────────┘
 ```
 
 **Key insight:** MCP server and OpenClaw plugin share the same SQLite file. SQLite supports concurrent readers + WAL mode for writer concurrency. No sync protocol needed.
 
 ## Entry point
 
-`src/mcp-server.ts` — standalone Node.js process.
+`src/mcp-server.ts` — standalone Node.js process. Supports two transports:
+
+### stdio mode (default)
 
 ```bash
 # Run directly
@@ -38,13 +40,25 @@ npx tsx src/mcp-server.ts --db ~/.openclaw/memory/memex/memex.sqlite
 memex-mcp --db ~/.openclaw/memory/memex/memex.sqlite
 ```
 
+### HTTP daemon mode (deployed)
+
+```bash
+memex-mcp --http 7878 --http-host 0.0.0.0 --auth-token <token> \
+  --db ~/.openclaw/memory/memex/memex.sqlite \
+  --embed-endpoint http://<proxy-host>:<port>/v1/embeddings \
+  --embed-api-key <key> --embed-model qwen3-embedding
+```
+
+The HTTP daemon runs as a long-lived process (managed by systemd). Each MCP client session gets its own `McpServer` instance with a dedicated `StreamableHTTPServerTransport`. Bearer token auth protects all non-/health endpoints.
+
 ## SDK
 
-`@modelcontextprotocol/sdk` v1.29.0 (already in node_modules via openclaw transitive dep).
+`@modelcontextprotocol/sdk` ^1.29.0 — now a **direct dependency** in `package.json` (was transitive via openclaw; broke on bump, fixed in PR #104).
 
 ```typescript
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";  // or use SDK's zod-compat
 ```
 
@@ -60,9 +74,10 @@ Output: { id: string, text: string, category: string, importance: number }
 
 ### memory_recall
 ```
-Input:  { query: string, limit?: number }
-Output: { results: [{ id, text, category, score }] }
+Input:  { query: string, limit?: number, scopes?: string[], agent_id?: string, session_id?: string }
+Output: { results: [{ id, anchor, text, category, scope, score, source }] }
 ```
+Supports hybrid retrieval (vector + BM25). The `source` field indicates provenance: "vector", "lexical", "both", or "reranked". Reranking is env-var gated (cross-encoder via MEMEX_RERANK_*, LLM reranker via MEMEX_RERANK_LLM_MODEL). Falls back to BM25-only when no embedder is configured.
 
 ### memory_forget
 ```
@@ -104,26 +119,44 @@ This works because the MCP server is a long-lived process (stdio keeps it alive 
 
 ## Embedding
 
-The MCP server needs an embedder for `memory_recall` (vector search) and `memory_store` (embed new memories). Options:
+The MCP server needs an embedder for `memory_recall` (vector search) and `memory_store` (embed new memories). The embedder uses an OpenAI-compatible API endpoint. Current production deployment uses qwen3-embedding (Qwen3-Embedding-4B) routed through a single llm-proxy.
 
+Options:
 1. **Require embedding endpoint** — `--embed-endpoint` and `--embed-api-key` CLI flags
 2. **BM25-only fallback** — if no embedder configured, use FTS-only search (degraded but functional)
 
-Start with option 1 (required). The user already has an embedding endpoint configured for OpenClaw.
+The daemon runs with option 1 in production. When `--embed-endpoint` is absent, the server prints a warning and falls back to BM25-only mode.
 
 ## CLI flags
 
 ```
---db <path>           SQLite database path (required)
---embed-endpoint <url> Embedding API endpoint (required for vector search)
---embed-api-key <key>  Embedding API key
---embed-model <name>   Embedding model name
---dream-interval <ms>  Dream cycle interval (default: 86400000 = 24h)
---no-dream            Disable background dreaming
+--db <path>            SQLite database path (required, or MEMEX_DB_PATH)
+--embed-endpoint <url>  Embedding API endpoint (required for vector search)
+--embed-api-key <key>   Embedding API key
+--embed-model <name>    Embedding model name
+--embed-dim <int>       Embedding dimensions (optional, auto-detected)
+--http <port>           Enable HTTP daemon mode (default: stdio)
+--http-host <host>      HTTP bind host (default: 127.0.0.1)
+--auth-token <token>    Bearer token for HTTP auth (MEMEX_AUTH_TOKEN)
+--llm-endpoint <url>    LLM API endpoint for dreaming reflection
+--llm-model <name>      LLM model name for dreaming reflection
+--llm-api-key <key>     LLM API key (falls back to embed API key)
+--llm-timeout <ms>      LLM request timeout in ms
+--dream-interval <ms>   Dream cycle interval (default: 86400000 = 24h)
+--no-dream              Disable background dreaming
 ```
+
+Additional env vars (not CLI flags):
+- `MEMEX_RERANK_ENDPOINT`, `MEMEX_RERANK_API_KEY`, `MEMEX_RERANK_MODEL` — cross-encoder reranker
+- `MEMEX_RERANK_LLM_MODEL` — opt-in LLM reranker (requires MEMEX_LLM_ENDPOINT)
+- `MEMEX_HARD_MIN_SCORE_OVERRIDE` — runtime override for the score floor
+- `MEMEX_RELEVANCE_FIRST` — opt-in temporal signal caps
+- `MEMEX_DEBUG_RECALL` — writes per-turn debug snapshots
+- `MEMEX_CLIENT_NAME` — overrides auto-detected MCP client identity
 
 ## .mcp.json for Claude Code
 
+### Local stdio mode:
 ```json
 {
   "mcpServers": {
@@ -131,18 +164,45 @@ Start with option 1 (required). The user already has an embedding endpoint confi
       "command": "npx",
       "args": ["tsx", "/path/to/memex/src/mcp-server.ts",
                "--db", "~/.openclaw/memory/memex/memex.sqlite",
-               "--embed-endpoint", "http://<embed-host>:<port>/v1/embeddings",
-               "--embed-api-key", "your-key"],
-      "env": {}
+               "--embed-endpoint", "http://<proxy-host>:<port>/v1/embeddings",
+               "--embed-api-key", "<key>"],
+      "env": {
+        "MEMEX_RERANK_ENDPOINT": "http://<proxy-host>:<port>/v1/rerank",
+        "MEMEX_RERANK_API_KEY": "<key>",
+        "MEMEX_RERANK_MODEL": "Qwen3-Reranker-0.6B"
+      }
     }
   }
 }
 ```
 
+### Remote HTTP daemon mode (shared across devices):
+```json
+{
+  "mcpServers": {
+    "memex": {
+      "type": "http",
+      "url": "http://<memex-daemon-host>:<port>/mcp",
+      "headers": {
+        "Authorization": "Bearer ${MEMEX_AUTH_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Env vars for HTTP mode: `MEMEX_ENDPOINT` (base URL, e.g. `http://<host>:<port>/mcp`), `MEMEX_AUTH_TOKEN`.
+
 ## File structure
 
 ```
-src/mcp-server.ts      — entry point, CLI parsing, server setup
+src/mcp-server.ts       — entry point, CLI parsing, server setup (stdio + HTTP)
+src/retriever.ts         — MemoryRetriever (hybrid vector + BM25, reranker)
+src/rerankers/           — llm-reranker.ts (LLM-based relevance judge)
+src/transient-retry.ts   — retry helper (500/502/503/504 + timeouts)
+src/embedder.ts          — OpenAI-compatible embedding client
+src/memory.ts            — MemoryStore (SQLite + FTS5 + sqlite-vec)
+src/dreaming.ts          — memory consolidation (light/deep/reflection)
 tests/mcp-server.test.ts — unit tests (mock transport)
 ```
 

--- a/docs/design/memory-browser.md
+++ b/docs/design/memory-browser.md
@@ -4,7 +4,7 @@
 
 ## Problem statement
 
-The only way to inspect what memex has stored today is `openclaw memex list` / `openclaw memex search` — text-only, paginated by terminal height, hard to filter by category × scope × date × similarity simultaneously. Three things suffer:
+The only way to inspect what memex has stored today is `memory_list` / `memory_recall` (MCP tools) or `openclaw memex list` / `openclaw memex search` — text-only, paginated by terminal height, hard to filter by category × scope × date × similarity simultaneously. Three things suffer:
 
 1. **Trust building** — users (and we) don't have a quick way to look at "what does memex remember about me?"
 2. **Noise debugging** — when retrieval surfaces something weird, finding all related entries (same entity, same scope, same time window) is multi-step CLI work.
@@ -97,9 +97,9 @@ Self-contained: vanilla JS + CSS embedded in one HTML file. No build step. Serve
 
 ## Auth model
 
-Reuse `auth: "gateway"` from `/__memex/health`. The gateway already has bearer-token auth in front of HTTP routes. Anyone with the gateway's URL + token can hit it. Localhost-only by default (gateway binds to 127.0.0.1 unless explicitly Tailscale-exposed).
+Use `auth: "gateway"` pattern (same as `/__memex/health`, though note health is now exempt from auth as of #101). The gateway already has bearer-token auth in front of HTTP routes. Anyone with the gateway's URL + token can hit it. Localhost-only by default (gateway binds to 127.0.0.1 unless explicitly exposed).
 
-**No additional auth surface needed** — piggybacks on existing infra.
+**No additional auth surface needed** — piggybacks on existing infra. Browser routes should require auth (unlike the health probe).
 
 ## Security considerations
 

--- a/docs/design/memory-scoping.md
+++ b/docs/design/memory-scoping.md
@@ -142,3 +142,5 @@ Always captured server-side, orthogonal to tags: `project_root` (hash), `device_
 ## Known gap
 
 The plugin-side auto-recall hook (`index.ts`) still uses the legacy `scopeManager.getAccessibleScopes(agentId)` for the active-context scope set. It does not yet derive `project:` tags for the auto-recall filter because the plugin hook runs inside the OpenClaw gateway process where `process.cwd()` is the gateway's directory, not the agent's project directory. The standalone MCP server (stdio) correctly derives project tags because it has access to the client process's cwd. The plugin (effectively HTTP backend) needs the OpenClaw client to supply project context — deferred to T2.1/T2.2. See PROGRESS.md line ~34 for the same note.
+
+**Related shipped (2026-07-02):** Scope-visibility (#7, #100) — stats breakdowns show readable project names; `MEMEX_CLIENT_NAME` env var for client identity — landed on main independent of the scoping branch.

--- a/docs/design/model-bakeoff.md
+++ b/docs/design/model-bakeoff.md
@@ -1,6 +1,6 @@
 # model-bakeoff — quick go/no-go for a candidate reranker or embedder
 
-**Status:** Design draft. Built after the manual Qwen3-Reranker bakeoff on 2026-04-10 codified the workflow.
+**Status: Implemented (v0.7.0).** `scripts/bakeoff` (CLI entry point) and `tests/bakeoff/` (runner, criteria, cache-guard, tests) exist. The harness supports both reranker and embedder swaps. Domain eval has expanded from 15 to 26 queries since the original bakeoff. The workflow now covers 2 reranker variants (cross-encoder via qwen3-reranker, LLM-based via deepseek-v4-flash). Built after the manual Qwen3-Reranker bakeoff on 2026-04-10 codified the workflow.
 
 ## Problem
 
@@ -45,6 +45,7 @@ Required env vars (no hardcoded defaults; missing → fail with a clear message)
 | `MEMEX_LLAMA_SWAP_API_KEY` | from 1Password — auth header for the embed/rerank endpoints |
 | `MEMEX_BENCHMARK_OPENAI_API_KEY` | from 1Password — for GPT-4o e2e judging |
 | `EMBED_MODEL` | the *current* embedding model (used as the reference in reranker swaps) |
+| `EMBED_BASE_URL` | base URL of the inference host (from openclaw config or set explicitly) |
 
 The candidate's endpoint URL and model name are positional args, not env vars, because they're the thing that varies per candidate and should be visible in shell history.
 
@@ -54,14 +55,14 @@ Two stages, gated. The cheap stage runs first; if it fails decisively, the expen
 
 ### Stage 1 — fast benchmarks (target: < 60s wall clock, no LLM cost)
 
-1. **Domain eval** (N=15 queries, live memex DB) — both with and without the candidate, retrieval-only, no LLM reader
+1. **Domain eval** (N=26 queries as of 2026-07, live memex DB) — both with and without the candidate, retrieval-only, no LLM reader
 2. **fast-benchmark TIER=fast** (N=50 LongMemEval cached fixture) — both with and without the candidate, in-process fusion math + optional rerank, no LLM cost
 
 Output:
 ```
 === Stage 1 ===
               | baseline | candidate | Δ
-domain-eval   |   12/15  |   14/15   | +2  ✓
+domain-eval   |   18/26  |   20/26   | +2  ✓
 LME R@1       |   78%    |   82%     | +4  ✓
 LME R@3       |   90%    |   90%     |  0  ◯
 ```
@@ -146,9 +147,9 @@ const PASS_CRITERIA = {
 - **Multi-candidate sweep** — `bakeoff sweep <candidates.txt>` is a v2 feature. v1 does one candidate at a time.
 - **Statistical significance** — N=50 + N=15 is small enough that single-query swings dominate. Don't over-engineer the decision math; the criteria above are intentionally conservative.
 
-## When to build it
+## When it was built
 
-After this loop's commits land. The manual bakeoff codified today is the v1 spec — `bakeoff reranker` should produce the exact same comparison table I produced manually today, just in 5 minutes instead of 60.
+Shipped as part of v0.7.0. The `scripts/bakeoff` CLI and `tests/bakeoff/` harness produce the comparison table originally done manually — in ~5 minutes for a reranker swap.
 
 ## Connection to the methodology rule
 

--- a/docs/design/production-benchmark.md
+++ b/docs/design/production-benchmark.md
@@ -59,14 +59,14 @@ src/benchmark/
 Key wiring decisions:
 
 1. **Indexing path**: BEIR corpora become `documents` in memex's existing `documents` pool, not synthetic memories. This honestly tests the document-side production path. (Conversation memory is tested separately by LongMemEval.)
-2. **Embedding model**: same as production (Qwen3-Embedding-4B-Q8_0). Don't switch to BEIR-tuned models — defeats the point.
-3. **Reranker**: run twice — without and with Qwen3-Reranker-0.6B. Two columns in the report.
+2. **Embedding model**: same as production (qwen3-embedding via llm-proxy). Don't switch to BEIR-tuned models — defeats the point.
+3. **Reranker**: run three passes — without, with cross-encoder (qwen3-reranker via llm-proxy), and with LLM reranker (deepseek-v4-flash, ordering-based). Three columns in the report (cf. domain-eval: baseline 69%, cross-encoder 77%, LLM 85%).
 4. **Output**: structured JSON to `bench/beir-<dataset>-<timestamp>.json` + summary table.
 
 ## Expected runtime + cost
 
-- **Indexing**: ~65K documents at ~50 docs/sec via Qwen3-Embedding-4B-Q8_0 = ~22 min. One-time per dataset (cache embeddings).
-- **Querying**: 1500 queries × ~150ms p50 = ~3.75 min per pass. Two passes (no rerank, with rerank) = ~7.5 min.
+- **Indexing**: ~65K documents at ~50 docs/sec via qwen3-embedding = ~22 min. One-time per dataset (cache embeddings).
+- **Querying**: 1500 queries × ~150ms p50 = ~3.75 min per pass. Three passes (no rerank, cross-encoder, LLM) = ~11 min.
 - **Total wall-clock**: ~30 min for first run, ~10 min for cached re-runs.
 - **API cost**: zero if running against local Qwen3 + Qwen3-Reranker. (Could also run against GPT embeddings for a comparison column, but that's $$$.)
 
@@ -100,7 +100,7 @@ The README leaderboard table gets two clearly-labeled sections instead of a conf
 
 ## Out of scope for issue #19
 
-- **Live agent E2E benchmark** (does the agent's answer use the recalled context correctly?). That's a separate research lane closer to MemoryAgentBench (`arXiv:2507.05257`) — see roadmap T4.2.
+- **Live agent E2E benchmark** (does the agent's answer use the recalled context correctly?). That's a separate research lane closer to MemoryAgentBench (`arXiv:2507.05257`) — see roadmap T4.2. Note: `tests/domain-eval.ts` (26 queries, Wilson 95% CI) now fills part of this gap as the primary quality metric for recall — see `docs/design/recall-quality-design.md`.
 - **Multi-modal documents** (PDFs, images). BEIR is text-only; that's fine.
 - **Real-time streaming benchmark**. BEIR is batch-oriented.
 

--- a/docs/design/recall-quality-design.md
+++ b/docs/design/recall-quality-design.md
@@ -1,10 +1,12 @@
 # Recall Quality Design -- Canonical Spec
 
-**Status:** design · **Date:** 2026-07-01
+**Status:** design (with implementation notes) · **Date:** 2026-07-01 · **Updated:** 2026-07-11
 **Supersedes:** `retrieval-redesign.md`, `recall-validation-analysis-revised.md`, `feedback-loop.md`
 **Single source of truth for:** recall quality redesign, validation framework, feedback-loop boost, and sequencing.
 
 > This document is the canonical spec. The three source docs are archived; this doc is the authority for all recall-quality work going forward. It includes corrections from a spec-review pass (C1-C7) verified against current code at the listed file:line references.
+>
+> **Implementation status (2026-07-11):** Wave 0 is complete (PRs #95, #103). F5 (recordRecalls in MCP), F12 (hardMinScore wired), C1 (reranker enabled in MCP — both cross-encoder and LLM), and C3 (hardMinScore wired with MEMEX_HARD_MIN_SCORE_OVERRIDE kill-switch) are implemented. The LLM reranker (deepseek-v4-flash, ordering-based, opt-in via MEMEX_RERANK_LLM_MODEL) was added as a second reranker option alongside the cross-encoder. Changes 2 (zscore default), 4 (temporal caps), 5 (semantic dedup), 6 (AutoCut), 7 (abstention), and 8 (provenance) remain planned. See §1.4 for per-change status.
 
 ---
 
@@ -12,11 +14,11 @@
 
 memex retrieval returns ~20 results that are mostly noise. A leaked CoT fragment (`ca1b32c6`) tops unrelated queries at ~0.7 score. The 94% LongMemEval E2E headline (reported in PROGRESS.md) disguises the fact that:
 
-- **No eval tests the production config.** MCP `memory_recall` hardcodes `rerank:"none"` and `fusionMethod:"weighted"` (`mcp-server.ts:57` + `retriever.ts:148-152`). Every quality eval uses a different (better) config: zscore fusion, 0.8/0.2 weights (`domain-eval.ts:160-165`, `longmemeval-benchmark.ts:356-363`). The BEIR benchmark calls `hybridQuery()` from `src/search.ts:3326` -- a third, completely different code path that always reranks internally (`search.ts:3490`).
-- **The reranker is dead in production.** `mcp-server.ts:57` hardcodes `rerank:"none"`. `UnifiedRetriever` has zero quality-eval coverage. Published reranker-on numbers describe a code path users never hit.
-- **hardMinScore (0.40) is dead config.** `applyAdaptiveMinScore` (`retriever.ts:881-888`) hardcodes `max(best*0.3, 0.15)` and never reads `this.config.hardMinScore`. 8+ test files set `hardMinScore:0.0` believing they disabled the floor -- vacuously testing at a floor of 0.15 (or higher, depending on the best score).
-- **Temporal signals are double-applied, uncapped, and universal.** `timeDecay` (half-life 60d) and `recencyBoost` (+0.10) both apply to every query. Re3 ablation: removing a per-query temporal gate drops R@1 from 0.742 to 0.268. memex has no gate.
-- **The recall-frequency signal (`recall_count`) is 99.26% zero.** MCP `memory_recall` never calls `store.recordRecalls()` (`mcp-server.ts:245-261`). The live boost (`retriever.ts:806-808`) uses an in-memory `Map` that resets on restart -- it never reads the persistent column. Dreaming deprioritizes and may evict memories that users actively consume, because it believes they were never recalled (`dreaming.ts:168-183`).
+- **No eval tests the production config.** MCP `memory_recall` ~~hardcodes `rerank:"none"`~~ (FIXED v0.7.3 — now reads MEMEX_RERANK_* env vars, supports "cross-encoder" and "llm" modes) and used `fusionMethod:"weighted"` (`mcp-server.ts:76-83` + `retriever.ts:163`). Every quality eval uses a different (better) config: zscore fusion, 0.8/0.2 weights (`domain-eval.ts:160-165`). The BEIR benchmark calls `hybridQuery()` from `src/search.ts` -- a third, completely different code path that always reranks internally.
+- **The reranker was dead in production.** ~~`mcp-server.ts:57` hardcodes `rerank:"none"`.~~ (FIXED v0.7.3 — MCP server reads MEMEX_RERANK_ENDPOINT, MEMEX_RERANK_API_KEY, MEMEX_RERANK_MODEL and dynamically enables cross-encoder reranking. Also supports opt-in LLM reranker via MEMEX_RERANK_LLM_MODEL.) `UnifiedRetriever` has zero quality-eval coverage.
+- **hardMinScore was dead config.** ~~`applyAdaptiveMinScore` (`retriever.ts:881-888`) hardcodes `max(best*0.3, 0.15)` and never reads `this.config.hardMinScore`.~~ (FIXED v0.7.3 — now reads `this.config.hardMinScore`, default changed from 0.40 to 0.15, MEMEX_HARD_MIN_SCORE_OVERRIDE kill-switch wired in `createRetriever`.) 8+ test files set `hardMinScore:0.0` believing they disabled the floor -- vacuously testing at a floor of the wired config value.
+- **Temporal signals are double-applied, uncapped, and universal.** `timeDecay` (half-life 60d) and `recencyBoost` (+0.10) both apply to every query. Re3 ablation: removing a per-query temporal gate drops R@1 from 0.742 to 0.268. memex has no gate (MEMEX_RELEVANCE_FIRST env flag exists as opt-in, off by default).
+- **The recall-frequency signal (`recall_count`) was 99.26% zero.** ~~MCP `memory_recall` never calls `store.recordRecalls()` (`mcp-server.ts:245-261`).~~ (FIXED v0.7.3 — MCP recall now calls `store.recordRecalls()` in both the retriever path and the BM25 fallback path.) The live boost (`retriever.ts:806-808`) still uses an in-memory `Map` that resets on restart -- it never reads the persistent column. Dreaming deprioritizes and may evict memories that users actively consume, because it believed they were never recalled (`dreaming.ts:168-183`).
 - **E2E numbers conflate retrieval quality with LLM inference ability.** LongMemEval's synthetic chat histories mean GPT-4o cannot know the answers from pre-training, but it can infer plausible answers from persona-modeling. The published 94% E2E number has no zero-context baseline subtracted, so retrieval contribution is unknown.
 
 ### 0.1 Dual-Gate Iteration Thesis
@@ -44,12 +46,13 @@ Iteration is a closed loop: live-sampling reveals gaps → validation adds crite
 query → vector(0.7) + BM25(0.3)
       → weighted fusion (incomparable scales: cosine[0,1] vs unbounded BM25)
       → minScore ≥ 0.3
-      → [cross-encoder reranker: OFF -- mcp-server.ts:57 hardcodes rerank:"none"]
-      → + recencyBoost (+≤0.10, universal, halfLife 14d)              [retriever.ts:774]
-      → × importance (0.7-1.0)                                         [retriever.ts:800]
-      → × lengthNorm (charLen/500)                                      [retriever.ts:461-462]
-      → × timeDecay (×0.50-1.0, universal, halfLife 60d)               [retriever.ts:850]
-      → adaptiveFloor = max(best×0.3, 0.15)                            [retriever.ts:881-888]
+      → [cross-encoder reranker: DYNAMIC (env-var gated; "cross-encoder", "llm", or "none")]
+      → [LLM reranker: opt-in via MEMEX_RERANK_LLM_MODEL]
+      → + recencyBoost (+≤0.10, universal, halfLife 14d)              [retriever.ts:833]
+      → × importance (0.7-1.0)                                         [retriever.ts:865]
+      → × lengthNorm (charLen/500)                                      [retriever.ts:887]
+      → × timeDecay (×0.50-1.0, universal, halfLife 60d)               [retriever.ts:920]
+      → adaptiveFloor = max(best×0.3, config.hardMinScore)             [retriever.ts:945 — FIXED v0.7.3, was hardcoded 0.15]
       → noiseFilter / MMR
       → slice(limit=20)
 ```
@@ -92,39 +95,19 @@ Oversample → reranker threshold → empty if nothing clears the bar. **CORRECT
 
 ### 1.4 Change Specifications (with file:line references)
 
-#### Change 1: Enable reranker in MCP production path
+#### Change 1: Enable reranker in MCP production path -- IMPLEMENTED (v0.7.3, PR #103)
 
-**File:** `src/mcp-server.ts:51-58` (createRetriever call + env var reads), `src/retriever.ts:623` (rerankResults guard)
+**File:** `src/mcp-server.ts:63-84` (createRetriever call + env var reads), `src/retriever.ts:628` (rerankResults guard)
 
-**Current:** `createRetriever(store, embedder, { mode: "hybrid", rerank: "none" })` at `mcp-server.ts:57`. The MCP server never reads `MEMEX_RERANK_ENDPOINT`, `MEMEX_RERANK_API_KEY`, or `MEMEX_RERANK_MODEL` from the environment (zero references to these env vars in mcp-server.ts).
+**Implementation (complete):** The MCP server now reads `MEMEX_RERANK_ENDPOINT`, `MEMEX_RERANK_API_KEY`, and `MEMEX_RERANK_MODEL` from the environment. It dynamically sets `rerank: "cross-encoder"` when both endpoint and API key are set; `rerank: "none"` otherwise (preserving the prior safe default). Model default is `jina-reranker-v3`; override via env var.
 
-**Target:** Three changes required -- flipping `rerank:"none"` to `"cross-encoder"` is necessary but INSUFFICIENT. `rerankResults` (`retriever.ts:623`) guards on BOTH `config.rerank === 'cross-encoder'` AND `config.rerankApiKey`. Without the API key, the reranker stays dead even after the flip.
+**LLM reranker (also implemented):** A second reranker option, opt-in via `MEMEX_RERANK_LLM_MODEL`, uses a chat model (e.g., deepseek-v4-flash) as an ordering-based relevance judge (`src/rerankers/llm-reranker.ts`). When set, `rerank: "llm"` takes precedence over the cross-encoder. Requires `MEMEX_LLM_ENDPOINT`. Quality: baseline 69%, cross-encoder 77%, LLM reranker 85% (domain-eval, 26 queries, Wilson 95% CI).
 
-1. **Read env vars in `createMemexMcpServer` (`mcp-server.ts:51-58`):**
-   ```ts
-   const rerankEndpoint = process.env.MEMEX_RERANK_ENDPOINT;
-   const rerankApiKey = process.env.MEMEX_RERANK_API_KEY;
-   const rerankModel = process.env.MEMEX_RERANK_MODEL;
-   ```
-   These three env vars are currently only read by `domain-eval.ts` (lines 166-169). The MCP server must read them independently.
+**Graceful degradation:** Cross-encoder failures return fusion results unchanged (not cosine-fallback). LLM reranker failures also return fusion results unchanged. Both paths are in `retriever.ts:730-796`.
 
-2. **Pass as config overrides to `createRetriever()`:**
-   ```ts
-   createRetriever(store, embedder, {
-     mode: "hybrid",
-     rerank: "cross-encoder",
-     ...(rerankEndpoint ? { rerankEndpoint } : {}),
-     ...(rerankApiKey ? { rerankApiKey } : {}),
-     ...(rerankModel ? { rerankModel } : {}),
-   })
-   ```
-   This overrides `DEFAULT_RETRIEVAL_CONFIG` fields only when env vars are set. If env vars are absent, the reranker will initialize but fail gracefully via the existing fallback path (`retriever.ts:728-736`).
+**Prerequisite:** Deploy Qwen3-Reranker-0.6B via llama-swap (the same infra serving the embedder). This model is already deployed as of v0.7, replacing the stale BGE-reranker-v2-m3 (which had an 8K context bug). Reranker endpoint + API key configured via env vars, not hardcoded. **Model config:** Do NOT change the DEFAULT `rerankModel` (`jina-reranker-v3` in `retriever.ts:170`) -- it is a safe Jina fallback. Override via env var `MEMEX_RERANK_MODEL=Qwen3-Reranker-0.6B` in the production environment.
 
-3. **Implement `MEMEX_RERANK_MODEL` env var read:** This env var does not currently exist anywhere in the codebase. Add it to the MCP server (step 1 above). Also scan for stale comment-only env vars like `MEMEX_RERANK_BLEND_WEIGHT` (`retriever.ts:78`, mentioned in a comment but never read from `process.env`) -- either wire or remove the comment to avoid confusion.
-
-**Prerequisite:** Deploy Qwen3-Reranker-0.6B via llama-swap (the same infra serving the embedder). This model is already deployed as of v0.7, replacing the stale BGE-reranker-v2-m3 (which had an 8K context bug). Reranker endpoint + API key configured via env vars, not hardcoded. **Model config:** Do NOT change the DEFAULT `rerankModel` (`jina-reranker-v3` in `retriever.ts:171`) -- it is a safe Jina fallback. Override via env var `MEMEX_RERANK_MODEL=Qwen3-Reranker-0.6B` in the production environment.
-
-**CORRECTION (C5, C7):** This enables the reranker on the primary explicit recall path. Without this change, the entire reranker-dependent design is a NO-OP. Paired with the graceful-degradation fallback (`retriever.ts:728-736` already returns fusion results on reranker failure).
+**CORRECTION (C5, C7):** This enables the reranker on the primary explicit recall path. Paired with the graceful-degradation fallback.
 
 #### Change 2: Flip fusion method from weighted to zscore
 
@@ -138,21 +121,10 @@ Oversample → reranker threshold → empty if nothing clears the bar. **CORRECT
 
 **Note:** The file header comment at `retriever.ts:3` (`Combines vector search + BM25 full-text search with RRF fusion`) is stale and misleading. Update it to `Combines vector search + BM25 full-text search with weighted or zscore fusion` as part of this change. Do not replace "RRF" with just "zscore" -- the code still supports both `"weighted"` and `"zscore"` (`config.fusionMethod` union type at `retriever.ts:27`).
 
-#### Change 3: Wire hardMinScore into applyAdaptiveMinScore
+#### Change 3: Wire hardMinScore into applyAdaptiveMinScore -- IMPLEMENTED (v0.7.3, PR #95)
 
-**File:** `src/retriever.ts:881-888`
-**Current:**
-```ts
-private applyAdaptiveMinScore(results: RetrievalResult[]): RetrievalResult[] {
-  if (results.length === 0) return results;
-  const bestScore = results[0].score;
-  const relativeFloor = bestScore * 0.3;
-  const absoluteFloor = 0.15;                              // hardcoded, ignores config
-  const effectiveFloor = Math.max(relativeFloor, absoluteFloor);
-  return results.filter(r => r.score >= effectiveFloor);
-}
-```
-**Target:**
+**File:** `src/retriever.ts:945-951`
+**Implementation (complete):**
 ```ts
 private applyAdaptiveMinScore(results: RetrievalResult[]): RetrievalResult[] {
   if (results.length === 0) return results;
@@ -163,23 +135,9 @@ private applyAdaptiveMinScore(results: RetrievalResult[]): RetrievalResult[] {
   return results.filter(r => r.score >= effectiveFloor);
 }
 ```
+`DEFAULT_RETRIEVAL_CONFIG.hardMinScore` is now `0.15` (was `0.40`). The kill-switch `MEMEX_HARD_MIN_SCORE_OVERRIDE` is wired in `createRetriever` (`retriever.ts:1105-1108`), allowing rollback without redeploy.
 
-**CORRECTION (C2):** `hardMinScore: 0.40` is defined (`retriever.ts:108,162`) but never read. This change wires it.
-
-**Kill-switch / override env var:** `MEMEX_HARD_MIN_SCORE_OVERRIDE` does not currently exist anywhere in the codebase. Implement it in `createRetriever` (`retriever.ts:1032-1039`, where `RetrievalConfig` is assembled):
-```ts
-const override = process.env.MEMEX_HARD_MIN_SCORE_OVERRIDE;
-if (override !== undefined) {
-  const parsed = parseFloat(override);
-  if (isNaN(parsed) || parsed < 0 || parsed > 1) {
-    throw new Error(`MEMEX_HARD_MIN_SCORE_OVERRIDE must be a float in [0,1], got: ${override}`);
-  }
-  config.hardMinScore = parsed;
-}
-```
-This allows rollback without redeploy: set `MEMEX_HARD_MIN_SCORE_OVERRIDE=0.15` to revert to the current hardcoded behavior.
-
-This change MUST follow the calibration probe (F3 in Wave 1, §2.4 V2/V3) -- the empirical optimal value is established before wiring, not guessed.
+**CORRECTION (C2):** `hardMinScore` is no longer dead config. The test audit (§3.1) still applies: 8+ test files set `hardMinScore` values whose effective floor was previously hardcoded.
 
 #### Change 4: Cap temporal signals + add QDF gate
 
@@ -544,9 +502,9 @@ The boost is applied AFTER all relevance signals (reranker, recency, importance)
 | **fusionMethod** | weighted | zscore | zscore | RRF | weighted |
 | **vectorWeight** | 0.7 | 0.8 | 0.8 | N/A (RRF) | 0.7 |
 | **bm25Weight** | 0.3 | 0.2 | 0.2 | N/A (RRF) | 0.3 |
-| **rerank** | **none** (hardcoded) | none (RERANK=1 to enable) | none (RERANK=1 to enable) | **always on** (search.ts:3490) | cross-encoder |
+| **rerank** | **dynamic** (env-var gated: "cross-encoder", "llm", or "none") | env-var gated (RERANK env) | env-var gated (RERANK env) | **always on** (search.ts) | cross-encoder |
 | **minScore** | 0.3 | 0.05 | 0.05 | N/A | 0.3 |
-| **hardMinScore** | 0.40 (DEAD) | (not configured) | 0.10 (DEAD) | N/A | 0.40 (DEAD) |
+| **hardMinScore** | 0.15 (WIRED, was 0.40 dead) | (not configured) | 0.10 | N/A | 0.15 (WIRED, was 0.40 dead) |
 | **candidatePoolSize** | 20 | 30 | K*6 (~60) | N/A | 20 |
 | **recencyHalfLifeDays** | 14 | (default 14) | 0 | N/A | 14 |
 | **recencyWeight** | 0.10 | (default 0.10) | 0 | N/A | 0.10 |
@@ -554,8 +512,8 @@ The boost is applied AFTER all relevance signals (reranker, recency, importance)
 
 Key takeaways:
 1. **No eval matches the production config.**
-2. **hardMinScore is dead in all paths** -- any value set is silently ignored by `applyAdaptiveMinScore` (`retriever.ts:881-888` hardcodes `max(best*0.3, 0.15)`).
-3. **The DEFAULT config is never used anywhere** -- both MCP and evals override it.
+2. **hardMinScore is now wired** (v0.7.3) -- config value 0.15 is read by `applyAdaptiveMinScore`, with MEMEX_HARD_MIN_SCORE_OVERRIDE kill-switch.
+3. **The DEFAULT config is never used by evals** -- both MCP and evals override it. DEFAULT applies to the MCP path unless overridden by env vars.
 4. **Embedding model is unspecified** -- all calibration thresholds are model-specific.
 
 **Config field classification -- eval-only vs production:**
@@ -578,10 +536,10 @@ Implementers must not wire eval-only fields (`rerankBlendWeight`, `rerankScoreMo
 | # | Critical | Resolution in This Doc |
 |---|---|---|
 | C1 | RRF is not a one-line config flip (type + branch + mapping) | Adopted. Z-score fusion is the immediate target (§1.4 Change 2). RRF on memory path deferred to post-zscore measurement. |
-| C2 | hardMinScore is dead config (hardcoded floor, 8+ test files vacuously true) | Adopted. Wire hardMinScore (§1.4 Change 3). Audit plan (§3.1). Two-phase canary test. |
+| C2 | hardMinScore is dead config (hardcoded floor, 8+ test files vacuously true) | IMPLEMENTED (v0.7.3). hardMinScore wired to config at 0.15. MEMEX_HARD_MIN_SCORE_OVERRIDE kill-switch in createRetriever. Test audit (§3.1) still applies. |
 | C3 | Fallback architecture contradicts primary path (RRF scores not on relevance scale) | Adopted. Z-score fallback used, not RRF. Relaxed floor on reranker failure. Best-effort fallback with confidence:"low" (§1.4 Change 7). |
 | C4 | Only 1 of 3 recall pipelines covered | Adopted. Three pipelines identified (§1.5). MCP path prioritized. UnifiedRetriever deferred to Wave 4 mixed-source benchmark. Document path out of scope. |
-| C5 | MCP memory_recall disables reranker (NO-OP for reranker-dependent design) | Adopted. Enable reranker in MCP path as Change 1 (§1.4). Prerequisite: Qwen3-Reranker-0.6B deployed. |
+| C5 | MCP memory_recall disables reranker (NO-OP for reranker-dependent design) | IMPLEMENTED (v0.7.3). MCP path reads MEMEX_RERANK_* env vars and dynamically enables "cross-encoder" or "llm" reranker. |
 | C6 | Abstention has zero agent guardrails | Adopted. Three-part guardrail: confidence field + sentinel result + agent instruction (§1.4 Change 7). |
 | C7 | Reranker is single point of failure | Adopted. Graceful-degradation path preserved (`retriever.ts:728-736`). Best-effort fallback with relaxed floor + confidence:"low" (§1.4 Change 7). |
 
@@ -593,12 +551,12 @@ Implementers must not wire eval-only fields (`rerankBlendWeight`, `rerankScoreMo
 - embedding model sensitivity: calibration probe now includes 2+ embedding models (F3/F18).
 - **Gap 11 / C2 crosswalk:** Gap 11 (hardMinScore dead config) in §2.2 is resolved by C2/Change 3. The 17-gaps list in §2.2 tracks the validation-doc gap inventory; the Change 3 spec (§1.4) and test audit (§3.1) track the implementation. Both references point to the same fix; there is no inconsistency.
 - **Sentinel id:** Changed from `__no_strong_match__` to `memex:abstention:no_strong_match` (namespace-prefixed, avoids collision with UUID-based entry IDs and any future `__`-prefixed internal conventions).
-- **retriever.ts:3 header comment:** Updated from `RRF fusion` to `Combines vector search + BM25 full-text search with weighted or zscore fusion` as part of Change 2.
+- **retriever.ts:3 header comment:** Still says `RRF fusion` (UNFIXED as of v0.7.3). Should be updated to `Combines vector search + BM25 full-text search with weighted or zscore fusion` as part of Change 2.
 
 ## Appendix C: Related Files
 
-- `/home/ubuntu/projects/memex/src/retriever.ts` -- RetrievalConfig (line 19), DEFAULT_RETRIEVAL_CONFIG (line 148), MemoryRetriever.retrieve() (line 330), fuseResults (line 513), recencyBoost (line 774), importanceWeight (line 800), lengthNormalization (line 461), timeDecay (line 850), applyAdaptiveMinScore (line 881) with hardcoded `max(best*0.3, 0.15)`, rerankResults (line 623), ephemeral freqBoost (line 806), graceful-degradation (line 728-736), stale RRF header comment (line 3)
-- `/home/ubuntu/projects/memex/src/mcp-server.ts` -- createRetriever with rerank:"none" (line 57), memory_recall handler (line 245-261, no recordRecalls), BM25-only fallback (line 266)
+- `/home/ubuntu/projects/memex/src/retriever.ts` -- RetrievalConfig (line 20), DEFAULT_RETRIEVAL_CONFIG (line 159), MemoryRetriever.retrieve() (line 356), fuseResults (line 524), recencyBoost (line 833), importanceWeight (line 865), lengthNormalization (line 887), timeDecay (line 920), applyAdaptiveMinScore (line 945, now wired to config.hardMinScore), rerankResults (line 628), ephemeral freqBoost (line 871), graceful-degradation (line 730-747), stale RRF header comment (line 3, UNFIXED), LLM reranker branch (line 752-796), MEMEX_HARD_MIN_SCORE_OVERRIDE (line 1105-1108), MEMEX_RELEVANCE_FIRST (line 1112-1115)
+- `/home/ubuntu/projects/memex/src/mcp-server.ts` -- createRetriever with dynamic rerank (line 76-83, reads MEMEX_RERANK_* env vars), memory_recall handler (line 225-297, now calls recordRecalls at line 275-278), BM25-only fallback (line 300-323, also calls recordRecalls at line 303), VERSION (line 24, stale at 0.7.2), LLM reranker wiring (line 71-74, 82)
 - `/home/ubuntu/projects/memex/src/memory.ts` -- MemoryEntry (line 21, missing recall_count), recall_count column (line 222), recordRecalls (line 848-852)
 - `/home/ubuntu/projects/memex/src/unified-retriever.ts` -- UnifiedRetriever (line 138), applyPostMergeModifiers (line 524-567)
 - `/home/ubuntu/projects/memex/src/search.ts` -- hybridQuery (line 3326), reciprocalRankFusion (line 2798), always-on reranker (line 3490)
@@ -608,7 +566,7 @@ Implementers must not wire eval-only fields (`rerankBlendWeight`, `rerankScoreMo
 - `/home/ubuntu/projects/memex/src/recall-cache.ts` -- Retrieval cache (89 lines, zero quality-eval coverage)
 - `/home/ubuntu/projects/memex/src/debug-recall.ts` -- MEMEX_DEBUG_RECALL path (145 lines, zero quality-eval coverage)
 - `/home/ubuntu/projects/memex/index.ts` (project root, not src/) -- line 1344: ONLY caller of recordRecalls (auto-recall hook path only)
-- `/home/ubuntu/projects/memex/tests/domain-eval.ts` -- 15 queries, MemoryRetriever, zscore fusion (line 160-165), binary metrics (line 193-197)
+- `/home/ubuntu/projects/memex/tests/domain-eval.ts` -- 26 queries, MemoryRetriever, zscore fusion (line 160-165), binary metrics, Wilson 95% CI, RERANK env supports "1"|"cross-encoder"|"llm"|"none", QUERY_DELAY_MS pacing
 - `/home/ubuntu/projects/memex/tests/longmemeval-benchmark.ts` -- 50 queries, MemoryRetriever, zscore fusion (line 356-363), temporal disabled (line 374-376), temp DB (line 273-274)
 - `/home/ubuntu/projects/memex/tests/beir-benchmark.ts` -- BEIR document retrieval, hybridQuery() (line 192-194), temp DB (line 148), always reranks
 - `/home/ubuntu/projects/memex/tests/helpers/ir-metrics.ts` -- nDCG@k (line 36-56), MRR, precision, recall (defined, unused in quality evals except BEIR)

--- a/docs/design/temporal-queries.md
+++ b/docs/design/temporal-queries.md
@@ -1,5 +1,7 @@
 # Temporal Queries Design
 
+**Status: Implemented but not yet wired into retrieval.** `src/temporal.ts` exports `detectTemporalRange()` and passes all unit + acceptance tests. However, the retriever import is present but the function is **not called** in the retrieval pipeline — the wiring step described below was gated behind `MEMEX_RELEVANCE_FIRST` (commit 3434df1, #96) and remains off by default. The import in `src/retriever.ts` line 10 is dead until the feature flag is enabled or the gate is removed.
+
 ## Problem
 
 Queries like "What happened last week?" or "What did I do yesterday?" carry
@@ -33,9 +35,9 @@ date range `[start, end]`, applied as a `WHERE timestamp BETWEEN` filter
 ### Wiring
 
 In `src/retriever.ts`:
-- Before calling `vectorSearch` / `bm25Search`, call `detectTemporalRange(query)`.
-- If a range is detected, pass it as an additional timestamp filter to both search paths.
-- The `MemoryStore` search methods accept an optional `timestampRange: [number, number]` parameter and add `WHERE timestamp BETWEEN ? AND ?` to the SQL.
+- `detectTemporalRange` is imported but **not yet called** in the retrieval pipeline.
+- The wiring step described in the original design (call before vectorSearch/bm25Search, pass timestampRange to search methods) was gated behind `MEMEX_RELEVANCE_FIRST` (#96) and has not shipped as an always-on feature.
+- When enabled, `MemoryStore` search methods accept an optional `timestampRange: [number, number]` parameter and add `WHERE timestamp BETWEEN ? AND ?` to the SQL.
 
 ### Trade-offs
 

--- a/docs/design/v0.8-architecture-decisions.md
+++ b/docs/design/v0.8-architecture-decisions.md
@@ -1,9 +1,9 @@
 # v0.8 Architecture Decisions
 
-**Status:** Decided. Confirmed verbally 2026-05-16; formalized here 2026-06-26.
+**Status:** Decided. Confirmed verbally 2026-05-16; formalized here 2026-06-26. Updated 2026-07-02 with scope-visibility progress and LLM reranker note.
 **Scope:** the four Tier-2 decisions from `docs/plans/013-post-v0.6.2-roadmap.md` §Tier 2 that blocked v0.8 from converging.
 
-These settle the "two problems" in `docs/plans/two-problems-architecture.md` enough to plan v0.8. Each is a deployment / data-shape decision — not new retrieval work (retrieval is solved; verified post-embedding-fix 2026-06-26, when the prod pool was re-embedded to 413/413).
+These settle the "two problems" in `docs/plans/two-problems-architecture.md` enough to plan v0.8. Each is a deployment / data-shape decision — not new retrieval work (retrieval quality is verified: domain-eval baseline 69%, cross-encoder 77%, LLM reranker 85%; see `docs/design/recall-quality-design.md`).
 
 ---
 
@@ -17,11 +17,11 @@ Cross-device document indexing is a distributed-filesystem problem, not a memory
 
 ## T2.2 — Daemon location: the always-on host
 
-The HTTP MCP daemon lives on the always-on host, co-located with the embedding + reranker workers (`Qwen3-Embedding-4B-Q8_0` + `Qwen3-Reranker-0.6B-Q8_0` on `<embed-host>:<port>`). This removes the embed network-hop from the recall hot path.
+The HTTP MCP daemon lives on the always-on host, co-located with the llm-proxy that fronts embedding + reranker workers (`qwen3-embedding` + `qwen3-reranker` on `<proxy-host>`). This removes the embed network-hop from the recall hot path.
 
 **Rationale:** the always-on host is always-on, already runs the embed/rerank workers 24/7, and tailnet ACL gives network-layer auth for free.
 
-**Current state (2026-06-26):** daemon still runs on the dev host as `memex.service` (systemd user unit, HTTP on a tailnet-accessible port). Migration to the always-on host (launchd unit + env/secret transfer off the dev host) is the **first v0.8 implementation task**. Carry-forward: the always-on host's <model-server> `healthCheckTimeout` had to be bumped 30→90s for the 4B embedding model (cold load under <model-server> exceeds 30s) — bake that into the deployment.
+**Current state (2026-07-02):** daemon still runs on the dev host as `memex.service` (systemd user unit, HTTP on a tailnet-accessible port). All inference (embed + rerank + LLM) routes through a single llm-proxy. Migration to the always-on host (launchd unit + env/secret transfer off the dev host) is the **first v0.8 implementation task**. Carry-forward: the always-on host's <model-server> `healthCheckTimeout` had to be bumped 30→90s for the 4B embedding model (cold load under <model-server> exceeds 30s) — bake that into the deployment. Dockerfile is built + smoke-validated (/health 200) but container is not deployed.
 
 ## T2.3 — Offline behavior: fail-closed
 
@@ -35,13 +35,17 @@ Conflicting / superseded memories are handled by the existing dreaming pipeline:
 
 **Rationale:** already implemented in `src/dreaming.ts`; preserves correction history (auditability) and matches the "learnings as first-class knowledge" design. No schema migration needed.
 
-**Current state:** reflection runs via the production **llm-proxy** (`<llm-proxy-host>:<port>`) → `deepseek-v4-flash` (policy: all LLM access via llm-proxy, never direct). Verified 2026-06-26.
+**Current state:** reflection runs via the production **llm-proxy** (`<llm-proxy-host>:<port>`) → `deepseek-v4-flash` (policy: all LLM access via llm-proxy, never direct). Same model serves the LLM reranker (`src/rerankers/llm-reranker.ts`, opt-in via `MEMEX_RERANK_LLM_MODEL`). Verified 2026-06-26.
 
 ---
 
 ## What this unblocks
 
-v0.8 planning can now assume: **always-on host daemon + per-device docs + fail-closed + Camp C.** The remaining architectural work is **Problem 2 — memory scoping / provenance** (device × project × agent): the data-model change that makes a shared pool usable without cross-context leak. As of 2026-06-26, 407/413 prod memories are `global` with no provenance metadata — that is the concrete gap to close.
+v0.8 planning can now assume: **always-on host daemon + per-device docs + fail-closed + Camp C.** The remaining architectural work is **Problem 2 — memory scoping / provenance** (device × project × agent): the data-model change that makes a shared pool usable without cross-context leak.
+
+**Progress update (2026-07-02):** Problem 2 is implemented on `feat/memory-scoping` (see `docs/design/memory-scoping.md`). Scope-visibility (#7) — readable project_name + stats breakdowns — shipped (#100). Multi-valued scope tags with server-authoritative derivation exist in `src/scope-derive.ts`; tag-intersection recall filters via `memory_scopes` join table. The feature branch is not yet merged to main.
+
+As of 2026-06-26, 407/413 prod memories are `global` with no provenance metadata — that is the concrete gap to close once scoping lands on main.
 
 ## Pointers
 

--- a/docs/flow.md
+++ b/docs/flow.md
@@ -15,7 +15,7 @@
                     └──────────┬──────────┘
                                │
               ┌────────────────┴────────────────┐
-              │  autoRecall: true? (default: no) │
+              │  autoRecall: true? (default: yes) │
               └────────────────┬────────────────┘
                           yes  │  no → skip
                                ▼
@@ -44,7 +44,7 @@
                      RESPONSE TO USER
                                │
               ┌────────────────┴────────────────┐
-              │ autoCapture: true? (default: no) │
+              │ autoCapture: true? (default: yes) │
               └────────────────┬────────────────┘
                           yes  │  no → done
                                ▼
@@ -149,8 +149,8 @@
   ✅ Memory instruction   ─── injected every turn (0ms)
   ✅ Tools                 ─── always available to LLM
   ✅ Auto-recall           ─── on by default (~150ms)
-  ❌ Auto-capture          ─── off (opt-in: autoCapture: true)
+  ✅ Auto-capture          ─── on by default (~834ms async)
   ✅ Doc indexer            ─── background, every 30min
 ```
 
-**Zero added latency per turn by default.** LLM decides when to recall/store via tools.
+**Auto-recall injects relevant memories before each turn (~150ms).** Auto-capture runs asynchronously after each turn (~834ms fire-and-forget). Both are on by default. LLM can also recall/store via tools.

--- a/docs/plans/00-overview.md
+++ b/docs/plans/00-overview.md
@@ -1,5 +1,7 @@
 # Memex Development Plan — Overview
 
+**Last reviewed: 2026-07-11.** This file is a historical index; it may not reflect current state. See PROGRESS.md for latest.
+
 ## Files
 
 | File | Contents | Review Priority |
@@ -12,20 +14,23 @@
 
 ## Decisions Needing Your Review
 
-### Resolved (April 2026)
+### Resolved (April–July 2026)
 
 | Project | Outcome |
 |---|---|
 | Entity Extraction | Shipped, net-neutral. Entity boost disabled (weight=0). Entity graph disabled by default. Gated behind config flags. |
 | Temporal Queries | Shipped. Regex date detection + timestamp filtering merged. |
 | Entity boost weight | Resolved: 0 (disabled). BM25 already captures keyword entities. |
-| Reflection LLM | Deferred. Light + deep dreaming work without LLM. Reflection phase is future work. |
+| Reflection LLM | Shipped (v0.7.0). Dreaming reflection phase: light + deep + LLM reflection via `/dream`. |
 | Eviction threshold | Resolved: 0.05. Implemented in deep sweep. |
+| MCP transport | Shipped (v0.7.0). HTTP + stdio, bearer auth, systemd+jiti deployment. |
+| MCP server | Shipped (v0.7.0). See `docs/design/mcp-server.md`. |
+| Session import | Killed. Real-time capture via `memory_store` replaces batch import. |
 
 ### Still Open
 
 | Question | Options | Current assumption |
 |---|---|---|
-| Temporal detection scope | Regex vs full NLP date parsing | Regex only — shipped, covers 80% |
-| MCP transport | stdio vs HTTP vs both | Not started |
 | Contradiction detection | Heuristic vs embedding similarity | Not started |
+| Memory hierarchy (topic->episode->fact) | Future architectural project | Not started |
+| Container daemon deploy | Dockerfile built + smoke-validated, not deployed | TBD |

--- a/docs/plans/003-session-import-v2.md
+++ b/docs/plans/003-session-import-v2.md
@@ -1,6 +1,6 @@
 # Session Import v2: Full-Transcript LLM Extraction
 
-> **Status: Open.** Not started. Highest-ROI quality project — 76% of memories are low-quality session imports.
+> **Status: KILLED.** Project killed per 02-projects.md — real-time capture via memory_store MCP tool replaces batch session import.
 > Note: tech stack references below are stale (LanceDB → SQLite, model names may have changed).
 
 **Goal:** Redesign the `import-sessions` pipeline to feed complete conversation transcripts (both user and assistant turns) into a capable LLM using session bin-packing into ~190K token windows, producing high-quality extracted memories with global scope and rich metadata provenance.

--- a/docs/plans/LEARNINGS.md
+++ b/docs/plans/LEARNINGS.md
@@ -1,4 +1,20 @@
-# Learnings — April 2026 Session
+# Learnings — April 2026 Session (+ updates through July 2026)
+
+**Note:** This is a historical learnings document. Most entries are from the April 2026 development cycle. Learnings remain valid lessons; some situations described have since been resolved (noted inline).
+
+## v0.7.3 post-release — dependency management takeaways
+
+- **typebox dual-package is a recurring hazard.** v0.7.1 had it with `@sinclair/typebox` vs `typebox`. v0.7.2 fixed it by switching to unscoped. v0.7.3 had it AGAIN because openclaw and memex resolved to different patch versions of `typebox` — `tools.ts` broke because `stringEnum` and `Type.Optional` came from different instances with incompatible nominal types. Fix: exact-pin `"typebox": "1.1.39"` in memex (must match openclaw's pin). Lesson: when two packages share a typebox dependency, the version must be an exact match, not a range.
+- **`@modelcontextprotocol/sdk` must be a direct dep.** It was resolved transitively through openclaw until openclaw dropped it — then memex broke. Declared as direct dep in #104 at `^1.29.0`. Lesson: if your package imports from a module directly in its own source, list it as a direct dependency.
+- **Node engine floor:** Raising to `>=22.19.0` was required by undici (via openclaw). Pinning ensures users get a clear error rather than cryptic runtime failures.
+
+## v0.7.3 recall-quality — LLM reranker, proxy wiring
+
+- **LLM reranker (ordering-based) beats cross-encoder.** At 22/26 = 85% vs 20/26 = 77% (Wilson CI). Design: ask the model to ORDER documents (comma-separated index list), not score them. Ordering -> rank-normalized scores. Uses `node:http` (not fetch) because the proxy's nginx returns empty bodies for undici chunked requests.
+- **Two reranker options now exist:** cross-encoder (qwen3-reranker, via `MEMEX_RERANK_*` env) and LLM reranker (deepseek-v4-flash, opt-in via `MEMEX_RERANK_LLM_MODEL`). LLM takes priority when both are configured.
+- **hardMinScore was dead config.** The default 0.40 was in the config schema but the retriever hardcoded 0.15. Fixed in #95 by wiring `hardMinScore` into `applyAdaptiveMinScore`. New default 0.15; kill-switch `MEMEX_HARD_MIN_SCORE_OVERRIDE`.
+- **`recordRecalls` was never called on the MCP path.** The in-memory `recallCounts` map (used for per-doc boost) was always empty — 99.26% of memories had recall_count=0. Fixed in #95 (F5): `store.recordRecalls()` now called on both hybrid path and BM25-only fallback.
+- **500 should be retried.** llama.cpp returns HTTP 500 for transient "Compute error" (OOM/queue-full) that recovers in seconds. Added to `transient-retry.ts` statuses `{500,502,503,504}`.
 
 ## v0.7.1 security bump — vulnerability deltas
 
@@ -99,6 +115,7 @@ Measured in 2026-04-10 against memex production DB (2105 memories) and cached Lo
 - **Qwen3-Reranker was a decisive win on LongMemEval** (+2 queries R@1, +2 queries E2E) and a small loss on domain eval (−1). The larger benchmark win (N=50 vs N=15) and clearer mechanism drove ship.
 - **Mechanism:** Qwen3-Reranker has 32K context (vs bge's 8K) — bge was truncating memex's chunked conversation sessions before scoring them. Qwen3-Reranker also emits sigmoid-calibrated [0,1] scores instead of bge's unbounded logits, which makes memex's "rerank skip on high confidence" code path actually meaningful.
 - **Lesson:** "Enable reranking" and "disable reranking" are not the real decision. The real decision is "which reranker." Don't extrapolate a finding across reranker families.
+- **July 2026 update:** This lesson proved correct again — the LLM reranker (deepseek-v4-flash, ordering-based) achieves 85% vs cross-encoder's 77% vs baseline 69% on the expanded 26-query domain eval. Reranker choice continues to dominate reranker-on/off.
 - **Process lesson:** The fix came from a separate Claude doing a full mechanistic research trail (`docs/research/embed-rerank-upgrade-brief.md` Conclusion section) — walking each rejected candidate through our actual failure modes, not just citing MTEB scores. This is the `Research Rigor: Diagnose Before Scoping` rule in action — and it worked this time.
 - **Latency follow-up:** memex made **10 /v1/rerank calls** during a single `openclaw agent main` turn in live verification. That's suspicious — the batch API takes N documents per call, so it should be 1-ish per retrieval. Possibly per-source duplication or the agent making multiple tool calls. Flagged for next-session investigation.
 

--- a/docs/plans/PROGRESS.md
+++ b/docs/plans/PROGRESS.md
@@ -1,6 +1,6 @@
 # Progress
 
-## Last Updated: 2026-07-08
+## Last Updated: 2026-07-11
 
 ## Session 2026-07-08 — F1 complete through llm-proxy + GPU contention resolved
 
@@ -28,11 +28,15 @@ All traffic now goes through the **llm-proxy** (k8s, v0.4.63) with circuit-break
 - Reranker and embed run on the same inference host — GPU contention was traced to a separate dev deployment, not the production path
 - Dev deployment (llama-swap on a secondary host) was shut down — only proxy-routed production remains
 - Daemon env points at the llm-proxy for both embed and rerank
-- `memex.env.example` updated with proxy URLs and model names
+- `memex.env.example` updated with proxy URLs and model names; `MEMEX_CLIENT_NAME` placeholder added (commented out)
 - `transient-retry.ts`: 500 added as retryable status (llama.cpp Compute error)
 - `domain-eval.ts`: `QUERY_DELAY_MS` env var for pacing (default 2s)
 - `MEMEX_CLIENT_NAME` set in daemon env (scope visibility)
-- Tests: 909/909 passing
+- Node engine floor raised to `>=22.19.0` (undici dep via openclaw; #105)
+- `better-sqlite3` bumped 11.x -> 12.11.1 (Node 26 compat; #75)
+- `@modelcontextprotocol/sdk` declared as direct dep (was transitive via openclaw; #104)
+- `typebox` exact-pinned to 1.1.39 to guarantee dedup with openclaw (#105, #106)
+- Tests: 909+ passing
 
 ### F3 Calibration — hardMinScore sweep
 
@@ -50,6 +54,15 @@ The default was lowered from 0.40 to 0.15 in #95. At 0.40 the reranker would hav
 1. Container daemon deploy
 2. Wire nDCG@5 into domain-eval (F16)
 3. Live-production sampling (V9)
+4. `openclaw.plugin.json` version bump to 0.7.3 and `openclawVersion` to 2026.6.11 (stale metadata)
+5. `openclaw.plugin.json` `hardMinScore` default still 0.40 — code default is 0.15 (stale config schema)
+
+### Post-v0.7.3 dependency bumps (2026-07-09..11)
+
+- **#104** — `@modelcontextprotocol/sdk` declared as direct dep (broke when openclaw dropped its transitive dep)
+- **#105** — Node engine floor `>=22.19.0` + typebox unscoped alignment (prevents dual-package install)
+- **#106** — typebox exact-pin to `1.1.39` (must match openclaw pin; dual-instance breaks `tools.ts`)
+- **#75** — `better-sqlite3` 11.x -> 12.11.1 (Node 26 compat)
 
 ### LLM Reranker Spike (ordering-based)
 

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -1,6 +1,7 @@
 # Memex Roadmap — Path to SOTA Memory System
 
-**Date:** 2026-04-12
+**Original date:** 2026-04-12 (historical vision document)
+**Status as of 2026-07-11:** Projects 1-3 shipped. Pool stats, domain-eval metrics, and "where memex is" below reflect April 2026 state; see PROGRESS.md for current metrics.
 **Research base:** 15 SOTA iterations (`agent-memory-sota-2026.md`), data quality research (`006-data-quality-research-apr2026.md`), session learnings (`LEARNINGS.md`)
 
 ---
@@ -67,7 +68,7 @@ Ordered by dependency and impact.
                                       → 6. Memory Hierarchy (future)
 ```
 
-### Project 1: Pool cleanup
+### Project 1: Pool cleanup ✅ SHIPPED (v0.7.x)
 **Goal:** Remove the noise floor so every subsequent improvement has clean data to work with.
 
 **What:**
@@ -81,7 +82,12 @@ Ordered by dependency and impact.
 
 **Measured by:** Pool size reduction, domain eval stability (should not regress), never-recalled ratio drop.
 
-### Project 2: MCP server
+**Shipped as:** Dreaming mechanical sweeps (dedup, noise removal, re-scoring, reflection). 13 noise entries purged (LLM meta-commentary). CoT/meta-commentary noise rule added.
+
+### Project 2: MCP server ✅ SHIPPED (v0.7.0)
+
+**Shipped as:** `src/mcp-server.ts` with HTTP+stdio transports, bearer auth, `/health` endpoint. Deployed via systemd+jiti behind Tailscale. Dockerfile built + smoke-validated. Cross-platform (OpenClaw + Claude Code). See original vision below:
+
 **Goal:** Memex as a standalone, always-on memory server. Cross-platform. Enables background processing.
 
 **What:**
@@ -100,7 +106,10 @@ Ordered by dependency and impact.
 
 **Measured by:** Platforms supported (≥2), background dreaming running, latency overhead (<10ms).
 
-### Project 3: Dreaming reflection
+### Project 3: Dreaming reflection ✅ SHIPPED (v0.7.0)
+
+**Shipped as:** Light sweep + deep sweep + LLM reflection phase (`src/dreaming.ts`). Reflection runs via `/dream` command or on a schedule in the MCP server. Dedicated LLM endpoint supported. See original vision below:
+
 **Goal:** LLM-driven knowledge synthesis — turn scattered facts into coherent learnings.
 
 **What:**
@@ -121,7 +130,7 @@ Session import was an OpenClaw-specific workaround for backfilling from historic
 
 Agents that want to bulk-import memories can use the `memory_store` MCP tool directly.
 
-### Project 4: Model bakeoff
+### Project 4: Model bakeoff 🔄 PARTIAL (ongoing)
 **Goal:** Evaluate whether newer models improve retrieval without architectural changes.
 
 **What:**
@@ -167,11 +176,15 @@ Agents that want to bulk-import memories can use the `memory_store` MCP tool dir
 
 ## Success criteria
 
-| Metric | Current | Target | Which project |
+**Note:** This table reflects April 2026 targets. Current state (July 2026) summarized below.
+
+| Metric | April 2026 | Target | Which project |
 |---|---|---|---|
 | Pool noise ratio | ~79% | < 20% | 1 (cleanup decay) |
 | Never-recalled ratio | 99% | < 60% | 1 (cleanup) + 3 (reflection) |
-| Domain eval | 12/15 (80%) | ≥ 14/15 | 3 (reflection) + 4 (models) |
-| LongMemEval E2E | 94% | ≥ 95% | 3 + 4 |
+| Domain eval | 12/15 (80%) | >= 14/15 | 3 (reflection) + 4 (models) |
+| LongMemEval E2E | 94% | >= 95% | 3 + 4 |
 | Memories with contradictions | Unknown | 0 detected | 3 (reflection) |
 | Learnings generated | 0 | 10+ per reflection cycle | 3 (reflection) |
+
+**July 2026 update:** Domain eval is now 26 queries: baseline 69%, cross-encoder 77%, LLM reranker 85% (Wilson CI). MCP path calls `recordRecalls` (F5 fix). LLM reranker added as opt-in second reranker option. See `docs/design/recall-quality-design.md` for the canonical quality plan.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "memex",
   "name": "Memex",
   "description": "Unified memory for OpenClaw: conversation memory + document search in a single SQLite database",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "kind": "memory",
   "contracts": {
     "tools": [
@@ -11,7 +11,8 @@
       "memory_forget",
       "document_search",
       "memory_stats",
-      "memory_list"
+      "memory_list",
+      "memory_update"
     ]
   },
   "configSchema": {
@@ -41,6 +42,7 @@
       "autoRecallLimit": { "type": "integer", "minimum": 1, "maximum": 10, "default": 3, "description": "Number of results to inject per turn (default: 3). R@3=90%, R@5=96%." },
       "autoCapture": { "type": "boolean", "default": true, "description": "Nudge LLM to store facts via memory_store tool" },
       "autoCaptureAgents": { "type": "array", "items": { "type": "string" }, "description": "Agent IDs to enable auto-capture for. Unset = all agents." },
+      "memoryAgents": { "type": "array", "items": { "type": "string" }, "description": "Unified agent whitelist for both recall + capture (v0.7.2+). Supersedes separate autoRecallAgents/autoCaptureAgents. Legacy keys extend via union semantics." },
       "documents": {
         "type": "object",
         "additionalProperties": false,
@@ -71,7 +73,7 @@
           "vectorWeight": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.7 },
           "bm25Weight": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.3 },
           "minScore": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.3 },
-          "hardMinScore": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.40 },
+          "hardMinScore": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.15 },
           "candidatePoolSize": { "type": "integer", "minimum": 10, "maximum": 100, "default": 20 },
           "timeDecayHalfLifeDays": { "type": "number", "minimum": 0, "maximum": 365, "default": 60 },
           "filterNoise": { "type": "boolean", "default": true }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
       "pluginApi": ">=2026.5.7"
     },
     "build": {
-      "openclawVersion": "2026.5.7"
+      "openclawVersion": "2026.6.11"
     }
   },
   "bin": {

--- a/plugin/memex-claude-code/README.md
+++ b/plugin/memex-claude-code/README.md
@@ -22,7 +22,7 @@ in Claude Code's `settings.json` `env` block — no shell exports needed:
 ```json
 {
   "env": {
-    "MEMEX_ENDPOINT": "http://<your-memex-host>:7878/mcp",
+    "MEMEX_ENDPOINT": "http://<your-memex-host>:8000/mcp",
     "MEMEX_AUTH_TOKEN": "PASTE_YOUR_TOKEN_HERE"
   }
 }
@@ -95,5 +95,9 @@ After installing, restart Claude Code. On the first user message, you should see
 Daemon logs show activity:
 
 ```sh
+# systemd (dev host):
 journalctl --user -u memex.service -f
+
+# Docker:
+docker compose logs -f memex
 ```


### PR DESCRIPTION
Swept all 70 docs via parallel review batches (9 agents over disjoint file sets). User-facing and current docs updated for accuracy; historical plan logs and research left as snapshots (one-line status corrections only).

## Key corrections across docs
- **Recall numbers:** domain-eval 15→26 queries, Wilson 95% CI — baseline 69% / cross-encoder 77% / LLM reranker 85%
- **Dead-config claims fixed:** hardMinScore is now WIRED at 0.15 (docs said 'dead config 0.40'); recordRecalls now called on MCP path (F5); reranker now enabled in MCP (was 'hardcoded none')
- **LLM reranker** documented throughout (ordering-based, opt-in `MEMEX_RERANK_LLM_MODEL`)
- **Dep state:** better-sqlite3 ^12.11.1 (Node 26 now supported), MCP SDK direct dep, typebox exact 1.1.39, node >=22.19.0
- **Deployment:** llm-proxy consolidation; transient-retry now retries 500
- `recall-quality-design.md`: per-change IMPLEMENTED/planned status header
- `CHANGELOG.md`: added 0.7.3 section

## Non-doc review catches
- `openclaw.plugin.json`: version 0.7.2→0.7.3, hardMinScore 0.40→0.15, add `memoryAgents` + `memory_update`. **Note:** `memory_dream` is daemon-only and was correctly NOT added to plugin contracts (it's not in `src/tools.ts`).
- `package.json`: `build.openclawVersion` 2026.5.7→2026.6.11

## Verification
- No infra/secret leaks (added-line scan clean)
- JSON valid (package.json, openclaw.plugin.json)
- Tests: 909/909

Generated with [Claude Code](https://claude.ai/code)