### PR TITLE
fix: bump /health VERSION constant to 0.7.3

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -21,7 +21,7 @@ import { detectCategory } from "../index.js";
 import { deriveScopes } from "./scope-derive.js";
 
 /** memex version — keep in sync with package.json (consumed by /health + MCP handshake). */
-const VERSION = "0.7.2";
+const VERSION = "0.7.3";
 
 // ============================================================================
 // Scope tag validation (Bug 5 fix)


### PR DESCRIPTION
`src/mcp-server.ts` `VERSION` was stale at `0.7.2` while `package.json` is `0.7.3`. `/health` and the MCP handshake reported the wrong version. Caught during local daemon redeploy verification (live daemon now reports `version: 0.7.3`).

No behavior change beyond the reported version string.

Generated with [Claude Code](https://claude.ai/code)