### PR TITLE
feat: debug capture as config + env-overrides-config layer

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@
 
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
 import { randomUUID } from "node:crypto";
+import { applyEnvOverrides, syncDebugEnvFromConfig } from "./src/env-overrides.js";
 import { homedir } from "node:os";
 import { join, dirname, basename, resolve } from "node:path";
 import { readFile, readdir, writeFile, mkdir } from "node:fs/promises";
@@ -110,6 +111,12 @@ interface PluginConfig {
   memoryInstructions?: "off" | string;
   /** Automatically purge noise entries from store on startup (default: false) */
   autoFixNoise?: boolean;
+  /**
+   * Per-query debug capture (default: off). `true` writes a trace per recall to
+   * the default debug dir; a string writes to that path. Overridable via the
+   * MEMEX_DEBUG_RECALL env var (env wins). See scripts/show-trace.ts.
+   */
+  debugRecall?: boolean | string;
   retrieval?: {
     mode?: "hybrid" | "vector";
     vectorWeight?: number;
@@ -295,6 +302,9 @@ const memoryUnifiedPlugin = {
 
     // Parse and validate configuration
     const config = parsePluginConfig(api.pluginConfig);
+    // Env vars override config (env > config > default). See src/env-overrides.ts.
+    applyEnvOverrides(config);
+    syncDebugEnvFromConfig(config);
 
     const resolvedDbPath = api.resolvePath(config.dbPath || getDefaultDbPath());
 
@@ -1884,6 +1894,7 @@ function parsePluginConfig(value: unknown): PluginConfig {
     autoCapture: cfg.autoCapture !== false,
     autoCaptureAgents: mergeAgentLists(cfg.memoryAgents, cfg.autoCaptureAgents),
     autoFixNoise: cfg.autoFixNoise === true,
+    debugRecall: cfg.debugRecall === true ? true : typeof cfg.debugRecall === "string" ? cfg.debugRecall : undefined,
     retrieval: typeof cfg.retrieval === "object" && cfg.retrieval !== null ? cfg.retrieval as any : undefined,
     scopes: typeof cfg.scopes === "object" && cfg.scopes !== null ? cfg.scopes as any : undefined,
     enableManagementTools: cfg.enableManagementTools === true,

--- a/memex.env.example
+++ b/memex.env.example
@@ -36,3 +36,27 @@ MEMEX_AUTH_TOKEN=
 MEMEX_HTTP_HOST=0.0.0.0
 MEMEX_HTTP_PORT=8000
 MEMEX_DB_PATH=/data/memex.sqlite
+
+# ─── Overrides (env wins over plugin config) ───────────────────────────────
+# For the standalone daemon these ARE the config. When memex runs as an openclaw
+# plugin, each var overrides the matching openclaw-config field (env > config),
+# so behavior can be flipped per-environment without editing config.
+
+# Per-query debug capture. 1 = default debug dir; a path = that dir; 0 = off.
+# Each recall writes a trace keyed by the debugId in the response; load with:
+#   node --import jiti/register scripts/show-trace.ts <debugId>
+MEMEX_DEBUG_RECALL=1
+
+# Flip auto-recall + results-per-turn without editing config.
+# MEMEX_AUTO_RECALL=1
+# MEMEX_AUTO_RECALL_LIMIT=3
+
+# Point reranking at a different backend per-environment (enables reranking).
+# MEMEX_RERANK_ENDPOINT=
+# MEMEX_RERANK_API_KEY=
+# MEMEX_RERANK_MODEL=
+# MEMEX_RERANK_PROVIDER=
+
+# Runtime hardMinScore floor for recall-quality experiments (float in [0,1]).
+# MEMEX_HARD_MIN_SCORE_OVERRIDE=0.15
+

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -43,6 +43,7 @@
       "autoCapture": { "type": "boolean", "default": true, "description": "Nudge LLM to store facts via memory_store tool" },
       "autoCaptureAgents": { "type": "array", "items": { "type": "string" }, "description": "Agent IDs to enable auto-capture for. Unset = all agents." },
       "memoryAgents": { "type": "array", "items": { "type": "string" }, "description": "Unified agent whitelist for both recall + capture (v0.7.2+). Supersedes separate autoRecallAgents/autoCaptureAgents. Legacy keys extend via union semantics." },
+      "debugRecall": { "type": ["boolean", "string"], "description": "Per-query debug capture (default: off). true = default debug dir; a string = custom dir. Each recall writes a trace keyed by the debugId returned in the response; load with scripts/show-trace.ts. Overridable via MEMEX_DEBUG_RECALL env." },
       "documents": {
         "type": "object",
         "additionalProperties": false,

--- a/src/env-overrides.ts
+++ b/src/env-overrides.ts
@@ -1,0 +1,92 @@
+/**
+ * Env-var overrides for plugin config (12-factor ops override).
+ *
+ * Precedence: **env > config > default**. When a supported env var is set it
+ * overrides the corresponding plugin-config field, so behavior can be flipped
+ * per-environment (daemon env, CI, a debug shell) without editing openclaw
+ * config. Supported vars are documented in memex.env.example.
+ *
+ * `applyEnvOverrides` mutates the config in place AND returns it, so call sites
+ * read the same `config` object unchanged. Pass an explicit `env` in tests to
+ * avoid polluting process.env.
+ */
+
+export interface RerankerConfigLike {
+  enabled?: boolean;
+  endpoint?: string;
+  apiKey?: string;
+  model?: string;
+  provider?: string;
+}
+
+export interface EnvOverridableConfig {
+  debugRecall?: boolean | string;
+  autoRecall?: boolean;
+  autoRecallLimit?: number;
+  reranker?: RerankerConfigLike;
+  retrieval?: { hardMinScore?: number };
+}
+
+const FALSY = new Set(["", "0", "false", "off", "no"]);
+
+/** True when v is a non-empty string (treats undefined/"" as absent). */
+function present(v: string | undefined): v is string {
+  return v !== undefined && v !== "";
+}
+
+/**
+ * Apply env overrides onto `config` in place. Returns the same config.
+ * Only overrides when the env var is present (non-empty); leaves config
+ * untouched otherwise so declarative config stays authoritative.
+ */
+export function applyEnvOverrides<T extends EnvOverridableConfig>(config: T, env: NodeJS.ProcessEnv = process.env): T {
+  // debugRecall ← MEMEX_DEBUG_RECALL ("1"/"0"/"true"/"false"/dir path)
+  if (present(env.MEMEX_DEBUG_RECALL)) {
+    config.debugRecall = env.MEMEX_DEBUG_RECALL;
+  }
+
+  // autoRecall ← MEMEX_AUTO_RECALL (falsy → off, anything else → on)
+  if (present(env.MEMEX_AUTO_RECALL)) {
+    config.autoRecall = !FALSY.has(env.MEMEX_AUTO_RECALL.toLowerCase());
+  }
+
+  // autoRecallLimit ← MEMEX_AUTO_RECALL_LIMIT (positive int)
+  if (present(env.MEMEX_AUTO_RECALL_LIMIT)) {
+    const n = parseInt(env.MEMEX_AUTO_RECALL_LIMIT, 10);
+    if (Number.isFinite(n) && n > 0) config.autoRecallLimit = n;
+  }
+
+  // Reranker ← MEMEX_RERANK_{ENDPOINT,API_KEY,MODEL,PROVIDER}; any one enables + merges
+  if (present(env.MEMEX_RERANK_ENDPOINT) || present(env.MEMEX_RERANK_API_KEY) || present(env.MEMEX_RERANK_MODEL) || present(env.MEMEX_RERANK_PROVIDER)) {
+    config.reranker = {
+      enabled: true,
+      endpoint: present(env.MEMEX_RERANK_ENDPOINT) ? env.MEMEX_RERANK_ENDPOINT : config.reranker?.endpoint,
+      apiKey: present(env.MEMEX_RERANK_API_KEY) ? env.MEMEX_RERANK_API_KEY : (config.reranker?.apiKey ?? "unused"),
+      model: present(env.MEMEX_RERANK_MODEL) ? env.MEMEX_RERANK_MODEL : config.reranker?.model,
+      provider: present(env.MEMEX_RERANK_PROVIDER) ? env.MEMEX_RERANK_PROVIDER : config.reranker?.provider,
+    };
+  }
+
+  // hardMinScore ← MEMEX_HARD_MIN_SCORE_OVERRIDE (float in [0,1])
+  if (present(env.MEMEX_HARD_MIN_SCORE_OVERRIDE)) {
+    const f = parseFloat(env.MEMEX_HARD_MIN_SCORE_OVERRIDE);
+    if (Number.isFinite(f) && f >= 0 && f <= 1) {
+      config.retrieval = { ...(config.retrieval ?? {}), hardMinScore: f };
+    }
+  }
+
+  return config;
+}
+
+/**
+ * Mirror config.debugRecall into process.env (only when env is unset) so the
+ * env-based debug machinery — resolveDebugDir() / writeDebugRecall() — honors a
+ * config-only debugRecall setting. No-op when MEMEX_DEBUG_RECALL is already set
+ * (env stays authoritative) or debugRecall is absent.
+ */
+export function syncDebugEnvFromConfig(config: EnvOverridableConfig, env: NodeJS.ProcessEnv = process.env): void {
+  if (env.MEMEX_DEBUG_RECALL !== undefined && env.MEMEX_DEBUG_RECALL !== "") return;
+  const d = config.debugRecall;
+  if (d === undefined) return;
+  env.MEMEX_DEBUG_RECALL = d === true ? "1" : d === false ? "0" : d;
+}

--- a/tests/env-overrides.test.ts
+++ b/tests/env-overrides.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Env-overrides-config (env > config > default). Verifies each supported env
+ * var overrides the matching config field when set, and leaves config alone
+ * when absent. Uses an explicit env object — never touches process.env.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { applyEnvOverrides, syncDebugEnvFromConfig } from "../src/env-overrides.js";
+
+const base = () => ({
+  embedding: { apiKey: "k" },
+  autoRecall: true,
+  autoRecallLimit: 3,
+  reranker: { enabled: false, endpoint: "config-endpoint", model: "config-model" },
+  retrieval: { hardMinScore: 0.15, vectorWeight: 0.7 },
+});
+
+describe("applyEnvOverrides (env > config)", () => {
+  it("MEMEX_DEBUG_RECALL overrides config.debugRecall", () => {
+    const cfg: any = { ...base(), debugRecall: false };
+    applyEnvOverrides(cfg, { MEMEX_DEBUG_RECALL: "1" });
+    assert.equal(cfg.debugRecall, "1");
+  });
+
+  it("MEMEX_AUTO_RECALL falsy disables, truthy enables", () => {
+    const off: any = { ...base() };
+    applyEnvOverrides(off, { MEMEX_AUTO_RECALL: "0" });
+    assert.equal(off.autoRecall, false);
+    const on: any = { ...base(), autoRecall: false };
+    applyEnvOverrides(on, { MEMEX_AUTO_RECALL: "true" });
+    assert.equal(on.autoRecall, true);
+  });
+
+  it("MEMEX_AUTO_RECALL_LIMIT overrides when positive int", () => {
+    const cfg: any = { ...base(), autoRecallLimit: 3 };
+    applyEnvOverrides(cfg, { MEMEX_AUTO_RECALL_LIMIT: "5" });
+    assert.equal(cfg.autoRecallLimit, 5);
+  });
+
+  it("MEMEX_RERANK_* enables + merges over the config reranker block", () => {
+    const cfg: any = { ...base() };
+    applyEnvOverrides(cfg, { MEMEX_RERANK_ENDPOINT: "env-endpoint", MEMEX_RERANK_MODEL: "env-model" });
+    assert.equal(cfg.reranker.enabled, true);
+    assert.equal(cfg.reranker.endpoint, "env-endpoint");
+    assert.equal(cfg.reranker.model, "env-model");
+    // Unspecified fields fall through to config.
+    assert.equal(cfg.reranker.apiKey, "unused");
+  });
+
+  it("MEMEX_HARD_MIN_SCORE_OVERRIDE sets retrieval.hardMinScore, preserves siblings", () => {
+    const cfg: any = { ...base() };
+    applyEnvOverrides(cfg, { MEMEX_HARD_MIN_SCORE_OVERRIDE: "0.4" });
+    assert.equal(cfg.retrieval.hardMinScore, 0.4);
+    assert.equal(cfg.retrieval.vectorWeight, 0.7, "sibling retrieval keys preserved");
+  });
+
+  it("leaves config untouched when no env vars are set", () => {
+    const cfg: any = { ...base() };
+    const before = JSON.parse(JSON.stringify(cfg));
+    applyEnvOverrides(cfg, {});
+    assert.deepEqual(cfg, before);
+  });
+
+  it("ignores invalid override values (bad int / out-of-range float)", () => {
+    const cfg: any = { ...base() };
+    applyEnvOverrides(cfg, { MEMEX_AUTO_RECALL_LIMIT: "not-a-number", MEMEX_HARD_MIN_SCORE_OVERRIDE: "9" });
+    assert.equal(cfg.autoRecallLimit, 3, "garbage int leaves config value");
+    assert.equal(cfg.retrieval.hardMinScore, 0.15, "out-of-range float leaves config value");
+  });
+});
+
+describe("syncDebugEnvFromConfig", () => {
+  it("mirrors config.debugRecall into env when env unset", () => {
+    const env: any = {};
+    syncDebugEnvFromConfig({ debugRecall: "/custom/dir" }, env);
+    assert.equal(env.MEMEX_DEBUG_RECALL, "/custom/dir");
+  });
+
+  it("normalizes boolean config to 1/0", () => {
+    const envT: any = {}; syncDebugEnvFromConfig({ debugRecall: true }, envT);
+    assert.equal(envT.MEMEX_DEBUG_RECALL, "1");
+    const envF: any = {}; syncDebugEnvFromConfig({ debugRecall: false }, envF);
+    assert.equal(envF.MEMEX_DEBUG_RECALL, "0");
+  });
+
+  it("does not overwrite an explicit env value", () => {
+    const env: any = { MEMEX_DEBUG_RECALL: "env-wins" };
+    syncDebugEnvFromConfig({ debugRecall: "/config/dir" }, env);
+    assert.equal(env.MEMEX_DEBUG_RECALL, "env-wins");
+  });
+});


### PR DESCRIPTION
Two related asks:

## 1. Debug capture is now config (not just an env var)
`debugRecall` is a first-class plugin-config field (`boolean | string`):
`true` = default debug dir, a string = custom dir. Added to `PluginConfig`, `parsePluginConfig`, and the `openclaw.plugin.json` configSchema. Documented in `memex.env.example`.

## 2. Env vars override config (env > config > default)
New `src/env-overrides.ts` (`applyEnvOverrides` + `syncDebugEnvFromConfig`) lets ops flip behavior per-environment without editing openclaw config. Applied at config intake in `index.ts`. Overridable fields:

| Env var | Config field |
|---|---|
| `MEMEX_DEBUG_RECALL` | `debugRecall` |
| `MEMEX_AUTO_RECALL` / `MEMEX_AUTO_RECALL_LIMIT` | `autoRecall` / `autoRecallLimit` |
| `MEMEX_RERANK_{ENDPOINT,API_KEY,MODEL,PROVIDER}` | `reranker` block (enables + merges) |
| `MEMEX_HARD_MIN_SCORE_OVERRIDE` | `retrieval.hardMinScore` |

For the standalone daemon these vars ARE the config (documented in `memex.env.example`); the override layer applies to the plugin path.

`syncDebugEnvFromConfig` bridges a config-only `debugRecall` into the env-based debug machinery (`resolveDebugDir`/`writeDebugRecall` read env), so config works even when env is unset.

Tests: **926/926** (+10 new env-overrides). Typecheck clean.

Generated with [Claude Code](https://claude.ai/code)