### PR TITLE
unify: single recall pipeline (UnifiedRetriever everywhere)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1269,22 +1269,21 @@ const memoryUnifiedPlugin = {
             for (const id of turnIds) recentlyRecalled.add(id);
           }
 
-          // Use unified recall (memory + docs) when available, fallback to memory-only
+          // Use unified retrieval (memory + docs) when available, fallback to memory-only
           let memoryContext: string;
           let resultCount = 0;
           const recalledIds: string[] = [];
-          if (unifiedRecall.hasDocumentSearch) {
+          const hasDocSearch = !!(documentSearchFn);
+          if (hasDocSearch) {
             // Filter document to current agent's workspace collection to prevent cross-agent context pollution
             const docCollection = (config.autoRecallDocFilter !== false && ctx?.workspaceDir)
               ? workspaceToCollection.get(ctx.workspaceDir)
               : undefined;
 
-            const results = await unifiedRecall.recall(recallQuery, {
-              // Use only the latest user turn for retrieval. The full built prompt can
-              // exceed local embedding backend context limits and pollute recall intent.
+            const results = await unifiedRetriever.retrieve(recallQuery, {
               limit: config.autoRecallLimit ?? 3,
               scopeFilter: accessibleScopes,
-              collection: docCollection,
+              collections: docCollection ? [docCollection] : undefined,
               recentlyRecalled,
             });
             if (results.length === 0) {

--- a/src/env-overrides.ts
+++ b/src/env-overrides.ts
@@ -17,6 +17,8 @@ export interface RerankerConfigLike {
   apiKey?: string;
   model?: string;
   provider?: string;
+  blendWeight?: number;
+  scoreMode?: string;
 }
 
 export interface EnvOverridableConfig {
@@ -25,7 +27,9 @@ export interface EnvOverridableConfig {
   autoRecallLimit?: number;
   reranker?: RerankerConfigLike;
   retrieval?: { hardMinScore?: number };
-  documents?: { paths: Array<{ path: string; name: string }> };
+  documents?: {
+    paths?: Array<{ path: string; name: string; pattern?: string }>;
+  };
 }
 
 const FALSY = new Set(["", "0", "false", "off", "no"]);


### PR DESCRIPTION
## Summary

Replaces the UnifiedRecall wrapper with direct UnifiedRetriever.retrieve() calls in the auto-recall hook. All three recall paths now use the same pipeline:

| Path | Before | After |
|---|---|---|
| Auto-recall (index.ts hook) | unifiedRecall.recall() (wrapper) | unifiedRetriever.retrieve() direct |
| Explicit recall (tools.ts) | unifiedRetriever.retrieve() | same |
| Daemon recall (mcp-server.ts) | unifiedRetriever.retrieve() | same |

One pipeline, one scoring model, one scope model, one trace surface.

## Changes

- index.ts: auto-recall hook calls unifiedRetriever.retrieve() directly (same options, same result shape)
- src/env-overrides.ts: fixed pre-existing type mismatches (documents.paths optional + pattern, RerankerConfigLike blendWeight/scoreMode)
- Typecheck clean, **941/941** tests green

Generated with [Claude Code](https://claude.ai/code)
