### PR TITLE
fix: MEMEX_DOC_PATHS wiring + collections metadata

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -600,13 +600,17 @@ export function createMemexMcpServer(options: McpServerOptions) {
         try {
           await indexAllPaths(docStore!.db, indexPaths);
           await embedDocuments(docStore!.db, dim, embedder!);
-          // Upsert collection metadata as public
+          // Upsert collection metadata for ALL active collections (they're the shared corpus)
           const now = new Date().toISOString();
-          for (const p of documents!.paths) {
-            docStore!.db.prepare(
-              `INSERT INTO document_collections (name, visibility, source, created_at) VALUES (?,?,?,?)
-               ON CONFLICT(name) DO NOTHING`
-            ).run(p.name, "public", "configured", now);
+          const activeColls = docStore!.db.prepare(
+            `SELECT DISTINCT collection FROM documents WHERE active = 1`
+          ).all() as { collection: string }[];
+          const stmt = docStore!.db.prepare(
+            `INSERT INTO document_collections (name, visibility, source, created_at) VALUES (?,?,?,?)
+             ON CONFLICT(name) DO NOTHING`
+          );
+          for (const { collection } of activeColls) {
+            stmt.run(collection, "public", "configured", now);
           }
         } catch { /* best effort — indexing must not crash the daemon */ }
       };
@@ -676,6 +680,17 @@ async function main() {
     apiKey: llmApiKey,
     ...(llmTimeout ? { timeout: llmTimeout } : {}),
   } : undefined;
+
+  // Documents: MEMEX_DOC_PATHS (comma-separated <abs-path>:<name>) → documents.paths
+  const docPathsRaw = process.env.MEMEX_DOC_PATHS;
+  const documents = docPathsRaw ? {
+    paths: docPathsRaw.split(",").map((entry) => {
+      const idx = entry.lastIndexOf(":");
+      return idx > 0
+        ? { path: entry.slice(0, idx), name: entry.slice(idx + 1) }
+        : { path: entry, name: entry.split("/").pop() || entry };
+    }),
+  } : undefined;
   if (reflectionLLM) {
     console.error(`memex-mcp: reflection enabled (model: ${llmModel}${llmTimeout ? `, timeout: ${llmTimeout}ms` : ""})`);
   }
@@ -687,6 +702,7 @@ async function main() {
     reflectionLLM,
     dreamIntervalMs: dreamInterval,
     noDream,
+    documents,
   };
   const { server, store } = createMemexMcpServer(sharedOptions);
 


### PR DESCRIPTION
Root cause: MEMEX_DOC_PATHS was set in the daemon env but never resolved into documents.paths in main() — sharedOptions didn't include it. The daemon never saw the configured paths, so configured-dir indexing never ran and document_collections stayed empty.

Fix: resolve MEMEX_DOC_PATHS in main() into documents.paths, pass into sharedOptions, and fix doIndex() to upsert document_collections for ALL active collections (not just the configured path name, which doesn't match auto-derived sub-collection names like virgil/main/infra).

Typecheck clean, 941/941.

Generated with [Claude Code](https://claude.ai/code)